### PR TITLE
Fix SSH workaround and recurse flag in calls to copy-to 

### DIFF
--- a/vtds_cluster_kvm/private/private_cluster.py
+++ b/vtds_cluster_kvm/private/private_cluster.py
@@ -321,7 +321,7 @@ class PrivateCluster:
             )
             connections.copy_to(
                 self.blade_config_path, "/root/blade_cluster_config.yaml",
-                "upload-cluster-config-to"
+                False, "upload-cluster-config-to"
             )
             info_msg(
                 "copying '%s' to all Virtual Blades at '/root/%s'" % (
@@ -330,7 +330,7 @@ class PrivateCluster:
             )
             connections.copy_to(
                 DEPLOY_SCRIPT_PATH, "/root/%s" % DEPLOY_SCRIPT_NAME,
-                "upload-cluster-deploy-script-to"
+                False, "upload-cluster-deploy-script-to"
             )
             cmd = (
                 "chmod 755 ./%s;"

--- a/vtds_cluster_kvm/private/scripts/deploy_cluster_to_blade.py
+++ b/vtds_cluster_kvm/private/scripts/deploy_cluster_to_blade.py
@@ -191,32 +191,6 @@ def read_config(config_file):
         ) from err
 
 
-def workaround_ssh_bug():
-    """There is a bug where the SSH server hangs in key exchange when
-    trying to talk to a Virtual Node that it can reach but that is not
-    on the same Virtual Blade as the client or the. The fix for this
-    is to explicitly configure a key exchange setting to what is
-    supposed to already be its default value in
-    '/etc/ssh/ssh_config'. This function makes sure that setting is in
-    that file.
-
-    """
-    with open('/etc/ssh/ssh_config', 'r', encoding='UTF-8') as ssh_config:
-        config_lines = ssh_config.readlines
-    # Grab the variable names that have settings and are not commented
-    # out in the file.
-    config_vars = [
-        config_line.split()[0]
-        for config_line in config_lines
-        if '#' not in config_line.split()[0]
-    ]
-    if 'KexAlgorithms' not in config_vars:
-        # No setting to address the issue, add one
-        config_lines += '    KexAlgorithms ecdh-sha2-nistp521\n'
-        with open('/etc/ssh/ssh_config', 'w', encoding='UTF-8') as ssh_config:
-            ssh_config.writelines(config_lines)
-
-
 def if_network(interface):
     """Retrieve the network name attached to an interface, raise an
     exception if there is none.
@@ -1068,20 +1042,11 @@ class VirtualNode:
         that the SSH servers will have host keys.
 
         """
-        # The '--append-line' is a workaround for a very weird SSH bug
-        # that makes SSH hang even though the connection works when
-        # going between VMs that are not on the same blade or between
-        # blades on the network and VMs that are on the network but
-        # not on the blade. Supposedly, it does nothing at all except
-        # explicitly set a value that is already the default in the
-        # SSH client, but it makes the problem go away.
         run_cmd(
             'virt-customize',
             [
                 '-a', self.boot_disk_name,
-                '--run-command', 'dpkg-reconfigure openssh-server',
-                '--append-line',
-                '/etc/ssh/ssh_config:    KexAlgorithms ecdh-sha2-nistp521'
+                '--run-command', 'dpkg-reconfigure openssh-server'
             ]
         )
 
@@ -1485,7 +1450,6 @@ def main(argv):
     blade_class = argv[0]
     blade_instance = argv[1]
     config = read_config(argv[2])
-    workaround_ssh_bug()
     network_installer = NetworkInstaller()
     network_installer.remove_virtual_network("default")
     # Only work with node classes that are hosted on our blade


### PR DESCRIPTION
## Summary and Scope

The SSH workaround was not working so it was simplified and fixed. Also fixed the copy-to calls for proper use of recurse.