### PR TITLE
Add non-cluster-network tagging to networks

### DIFF
--- a/vtds_cluster_kvm/api_objects.py
+++ b/vtds_cluster_kvm/api_objects.py
@@ -167,6 +167,16 @@ class VirtualNetworks(metaclass=ABCMeta):
 
         """
 
+    @abstractmethod
+    def non_cluster_network(self, network_name):
+        """A network in the cluster configuration may be a network
+        used by vTDS for constructing the cluster but not intended for
+        use by applications running on the cluster. Such a network is
+        a 'non-cluster network'.  Return True if the specified network
+        name refers to a non-cluster network otherwise return False.
+
+        """
+
 
 class NodeConnection(metaclass=ABCMeta):
     """A class containing the relevant information needed to use

--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -170,6 +170,15 @@ class PrivateVirtualNetworks(VirtualNetworks):
                 "the following Virtual Networks: %s" % str(missing_names)
             ) from err
 
+    def __network_by_name(self, network_name):
+        """Return the network configuration for the named network.
+        """
+        if network_name not in self.networks_by_name:
+            raise ContextualError(
+                "the Virtual Network named '%s' does not exist" % network_name
+            )
+        return self.networks_by_name[network_name]
+
     def __l3_config(self, network_name, family):
         """Get the l3_info block for the specified address family from
         the network of the specified name.  If the network doesn't
@@ -177,11 +186,7 @@ class PrivateVirtualNetworks(VirtualNetworks):
         return None.
 
         """
-        if network_name not in self.networks_by_name:
-            raise ContextualError(
-                "the Virtual Network named '%s' does not exist" % network_name
-            )
-        network = self.networks_by_name[network_name]
+        network = self.__network_by_name(network_name)
         candidates = [
             l3_info
             for _, l3_info in network.get('l3_configs', {}).items()
@@ -197,6 +202,10 @@ class PrivateVirtualNetworks(VirtualNetworks):
         if l3_config is None:
             return None
         return l3_config.get('cidr', None)
+
+    def non_cluster_network(self, network_name):
+        network = self.__network_by_name(network_name)
+        return network.get('non_cluster', False)
 
 
 class PrivateNodeConnection(NodeConnection):

--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -13,6 +13,10 @@ cluster:
     # automatically. This default configuration should work in most
     # cases, but can be modified as needed.
     network_name: bladenet
+    # This is not a cluster network (i.e. it should not be used by
+    # applications running on the cluster for anything). It is here to
+    # aid in setting up the cluster during deployment.
+    non_cluster: True
     # Do not set 'delete' to true here or in an overlay. This network
     # must be defined or the Cluster layer APIs that support
     # deployment at the Application layer will not all work correctly.


### PR DESCRIPTION
Add non-cluster network tagging to allow the application layer to choose not to include non-cluster networks in network lists.