### PR TITLE
Take the logs for node connections out of the with clause

### DIFF
--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -208,6 +208,7 @@ class PrivateVirtualNetworks(VirtualNetworks):
         return network.get('non_cluster', False)
 
 
+# pylint: disable=too-many-instance-attributes
 class PrivateNodeConnection(NodeConnection):
     """Private implementation of the NodeConnection Cluster Layer API
     Class.


### PR DESCRIPTION
## Summary and Scope

This takes setting up the standard output and standard error logging for node connections out of the with clause, where they will wind up being prematurely cleaned up on exit from the with, and makes them something that the class cleans up on its context exit instead.
