### PR TITLE
Add wait for node to deploy script, add SSH keepalive options

### DIFF
--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -232,6 +232,8 @@ class PrivateNodeConnection(NodeConnection):
         self.options = [
             '-o', 'NoHostAuthenticationForLocalhost=yes',
             '-o', 'StrictHostKeyChecking=no',
+            '-o', 'ServerAliveInterval=30',
+            '-o', 'ServerAliveCountMax=3',
         ]
         self.hostname = self.common.node_hostname(node_class, instance)
         self._connect()
@@ -307,6 +309,7 @@ class PrivateNodeConnection(NodeConnection):
                 ),
                 *self.options,
                 '-N',
+                '-T',
                 '-vvv',
                 '-p', str(ssh_port),
                 '-i', ssh_key_path,


### PR DESCRIPTION
## Summary and Scope

Fix race conditions in trying to use Virtual Nodes before they are ready by adding a wait in the deploy script that creates virtual nodes that waits for the SSH server to be accepting connections before declaring the cluster deployed. This addresses the fact that SSH port forwarding does not try to move traffic to the remote end of the forwarded port until actual traffic moves across the TCP connection. It accepts the TCP connection locally. This was causing intermittent failures at the application layer when trying to deploy applications onto Virtual Nodes.