### PR TITLE
Vsha 638

### DIFF
--- a/vtds_cluster_kvm/private/cluster.py
+++ b/vtds_cluster_kvm/private/cluster.py
@@ -71,6 +71,7 @@ class Cluster(ClusterAPI):
                 "no cluster configuration found in top level configuration"
             )
         self.provider_api = None
+        self.platform_api = None
         self.stack = stack
         self.build_dir = build_dir
         self.blade_config_path = path_join(
@@ -418,6 +419,7 @@ class Cluster(ClusterAPI):
 
     def prepare(self):
         self.provider_api = self.stack.get_provider_api()
+        self.platform_api = self.stack.get_platform_api()
         self.__add_host_blade_net()
         blade_config = self.config
         self.__expand_node_classes(blade_config)
@@ -483,9 +485,10 @@ class Cluster(ClusterAPI):
                 DEPLOY_SCRIPT_PATH, "/root/%s" % DEPLOY_SCRIPT_NAME,
                 False, "upload-cluster-deploy-script-to"
             )
+            python3 = self.platform_api.get_blade_python_executable()
             cmd = (
                 "chmod 755 ./%s;" % DEPLOY_SCRIPT_NAME +
-                "python3 " +
+                "%s " % python3 +
                 "./%s {{ blade_class }} {{ instance }} " % DEPLOY_SCRIPT_NAME +
                 "blade_cluster_config.yaml "
                 "/root/ssh_keys"

--- a/vtds_cluster_kvm/private/cluster.py
+++ b/vtds_cluster_kvm/private/cluster.py
@@ -507,3 +507,14 @@ class Cluster(ClusterAPI):
 
     def get_virtual_networks(self):
         return VirtualNetworks(self.common)
+
+    def get_node_venv_path(self):
+        python_config = self.config.get('python', {})
+        return python_config.get('node_venv_path', "/root/node-venv")
+
+    def get_node_python_executable(self):
+        # NOTE: do not use path_join() here to construct the path. The
+        # path here is being constructed for a Linux environment,
+        # where path separators are always '/' and which might not
+        # match the system this code is running on.
+        return "%s/bin/python3" % self.get_node_venv_path()

--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -1,4 +1,24 @@
 cluster:
+  # The python information here pertains to a shared Python Virtual
+  # Environment created by the Cluster layer for use of it and any
+  # higher layers (application layers) that might need it. Specifically,
+  # this allows the path to the virtual environment to be specified and
+  # it allows for the specification of Python modules to be
+  # pre-installed by the Cluster layer in that virtual environment for
+  # use by other layers.
+  python:
+    node_venv_path: /root/blade-venv
+    modules:
+    modules:
+      example:
+        # Install 
+        module_name: pyyaml
+        delete: true # this is an example, so don't really install it
+        source_type: pypi
+        metadata:
+          url: null
+          version: pyyaml~=6.0
+    
   # The 'host_blade_network' specifies the parameters for a
   # blade-local network used only among Virtual Nodes that share a
   # single blade and the blade itself. The addresses here are


### PR DESCRIPTION
## Summary and Scope

It turns out the recently added Python virtual environment methods for nodes do not belong in the cluster layer because the cluster layer does not manage resources on nodes, it simply sets up networks and nodes to be booted. Managing the resources on the nodes is an application layer activity, so setting up a virtual environment on the nodes falls to the application layer. Since the application layer is at the top of the stack, whether or not a python virtual environment should be created is entirely up to the application.
