### PR TITLE
Add features to begin supporting more complex Application Layer use cases

### DIFF
--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -74,8 +74,17 @@ class VirtualNodes(VirtualNodesBase):
     def node_count(self, node_class):
         return self.common.node_count(node_class)
 
+    def set_node_node_name(self, node_class, instance, name):
+        self.common.set_node_node_name(node_class, instance, name)
+
+    def node_node_name(self, node_class, instance):
+        return self.common.node_node_name(node_class, instance)
+
     def network_names(self, node_class):
         return self.common.node_networks(node_class)
+
+    def set_node_hostname(self, node_class, instance, name):
+        self.common.set_node_hostname(node_class, instance, name)
 
     def node_hostname(self, node_class, instance, network_name=None):
         return self.common.node_hostname(

--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -71,6 +71,9 @@ class VirtualNodes(VirtualNodesBase):
             if not node_class.get('pure_base_class', False)
         ]
 
+    def application_metadata(self, node_class):
+        return self.common.node_application_metadata(node_class)
+
     def node_count(self, node_class):
         return self.common.node_count(node_class)
 
@@ -203,6 +206,10 @@ class VirtualNetworks(VirtualNetworksBase):
 
     def network_names(self):
         return self.networks_by_name.keys()
+
+    def application_metadata(self, network_name):
+        network = self.__network_by_name(network_name)
+        return network.get('application_metadata', {})
 
     def ipv4_cidr(self, network_name):
         l3_config = self.__l3_config(network_name, 'AF_INET')

--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -91,6 +91,9 @@ class VirtualNodes(VirtualNodesBase):
             node_class, instance, network_name
         )
 
+    def node_host_blade_info(self, node_class):
+        return self.common.node_host_blade_info(node_class)
+
     def node_ipv4_addr(self, node_class, instance, network_name):
         return self.common.node_ipv4_addr(node_class, instance, network_name)
 

--- a/vtds_cluster_kvm/private/cluster.py
+++ b/vtds_cluster_kvm/private/cluster.py
@@ -401,7 +401,7 @@ class Cluster(ClusterAPI):
         """Add the contents of the libvirt XML template for
         configuring a node class to the node class. This is done on a
         per-node class basis because it will be more flexible in the
-        long run. For now it is the same data in ever node class,
+        long run. For now it is the same data in every node class,
         which is a bit wasteful, but no big deal.
 
         """

--- a/vtds_cluster_kvm/private/common.py
+++ b/vtds_cluster_kvm/private/common.py
@@ -451,21 +451,27 @@ class Common:
         virtual_blades = self.stack.get_provider_api().get_virtual_blades()
         return virtual_blades.blade_ssh_key_paths(host_blade_class)
 
+    def node_host_blade_info(self, node_class):
+        """Return the information about the host Virtual Blade on which the
+        specified node lives.
+
+        """
+        instance_capacity = self.__host_blade_instance_capacity(node_class)
+        return {
+            'blade_class': self.__host_blade_class(node_class),
+            'instance_capacity': instance_capacity
+        }
+
     def node_host_blade(self, node_class, instance):
         """Get a tuple containing the the blade class and instance
         number of the Virtual Blade that hosts the Virtual Node
         instance 'instance' of the given node class.
 
         """
-        if instance < 0:
-            raise ContextualError(
-                "internal error: requesting the node host blade for a "
-                "negative instance number (%d) of node class '%s'" % (
-                    instance, node_class
-                )
-            )
-        host_blade_class = self.__host_blade_class(node_class)
-        instance_capacity = self.__host_blade_instance_capacity(node_class)
+        self.__check_node_instance(node_class, instance)
+        info = self.node_host_blade_info(node_class)
+        host_blade_class = info['blade_class']
+        instance_capacity = info['instance_capacity']
         return (host_blade_class, int(instance / instance_capacity))
 
     def node_host_blade_ip(self, node_class, node_instance):

--- a/vtds_cluster_kvm/private/common.py
+++ b/vtds_cluster_kvm/private/common.py
@@ -313,6 +313,14 @@ class Common:
         """
         return self.build_directory
 
+    def node_application_metadata(self, node_class):
+        """Retrieve the Application Metadata for a named Node Class
+        from the configuration.
+
+        """
+        nclass = self.__get_node_class(node_class)
+        return nclass.get('application_metadata', {})
+
     def set_node_node_name(self, node_class, instance, name):
         """When called during the 'prepare' phase, this allows the
         caller to change the node name (in the

--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -169,6 +169,19 @@ cluster:
             pools:
               - start: 10.254.1.0
                 end: 10.254.255.254
+      # Applications sometimes need concrete configuration information
+      # that is most appropriately stored with the objects implemented
+      # within the layers instead of trying to map information onto
+      # those objects abstractly at the application layer. The
+      # application_metadata section of the configuration is only
+      # understood by a given application layer and provides a place to
+      # put such information. The intent here is that a specific
+      # configuration set used for a given application may place
+      # metadata with API objects for use by the application itself. Use
+      # of application_metadata should be done sparingly and with
+      # caution because it has the power to entangle a given vTDS stack
+      # and make it non-portable.
+      application_metadata: {}
   node_classes:
     ubuntu_24_04_node:
       # If 'pure_base_class' is present and 'true' this Virtual Node
@@ -358,3 +371,16 @@ cluster:
               # network. If it is an empty string or unspecified, the
               # node hostname will be used unmodified on this network.
               hostname_suffix: "-mynet"
+      # Applications sometimes need concrete configuration information
+      # that is most appropriately stored with the objects implemented
+      # within the layers instead of trying to map information onto
+      # those objects abstractly at the application layer. The
+      # application_metadata section of the configuration is only
+      # understood by a given application layer and provides a place to
+      # put such information. The intent here is that a specific
+      # configuration set used for a given application may place
+      # metadata with API objects for use by the application itself. Use
+      # of application_metadata should be done sparingly and with
+      # caution because it has the power to entangle a given vTDS stack
+      # and make it non-portable.
+      application_metadata: {}

--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -266,7 +266,8 @@ cluster:
                 # shown here as 'false' for completeness.
                 delete: false
       node_naming:
-        # This block drives naming of nodes of this type. At a
+        # This block drives naming of nodes of this type within the
+        # context of libvirt (i.e. the virtual machine name). At a
         # minimum, this block must contain a 'base_name' field that
         # specifies the base name for numbered instances of nodes. An
         # optional 'node_names' list may be specified as well. Virtual
@@ -280,6 +281,30 @@ cluster:
         # exist.
         base_name: ubuntu-node
         node_names: []
+      host_naming: {}
+        # This block drives network host naming of nodes of this type. At a
+        # minimum, this block must contain a 'base_name' field that
+        # specifies the base name for numbered instances of nodes. An
+        # optional 'hostnames' list may be specified as well. Virtual
+        # Nodes created from this class will assigned host namesn first
+        # from the list of host names until that is exhausted, then will be
+        # assigned a 'numbered' host name composed as follows:
+        #
+        #     <base-name>-<instance number>
+        #
+        # for all instances for which a 'host_name' entry does not
+        # exist. In adition to the naming rules above, there is also an
+        # optional per-network suffix that can be applied to a host name
+        # to differentiate the host on that network in DNS. See
+        #
+        #    network_interfaces.addr_info.hostname_suffix
+        #
+        # below.
+        #
+        # The following are example values:
+        #
+        # base_name: ubuntu-host
+        # hostnames: []
       network_interfaces:
         # The list of network interfaces to nodes of this type and the
         # configuration for each network connection. These associate


### PR DESCRIPTION
## Summary and Scope

- Add methods to set node and host names on Virtual Nodes during the prepare phase. This permits the use of XNAMEs or other Application specific non-hostname node identifiers as VM names which are addressable by our special fork of Sushy-Tools. The need for this was driven by vShasta which wants to use Sushy-Tools as its Redfish BMC emulator and wants to be able to address nodes by XNAME, a construct best computed at the application layer.
- Add the node_host_blade() API method to allow applications to learn the name of the host blade that hosts a given class of Virtual Nodes and the number of Virtual Node instances that can be hosted by that host blade. This was driven by vShasta which needs that information to compose the XNAME node names correctly for use in creating Virtual Nodes.
- Add application_metadata to configuration API objects and methods to the APIs to retrieve application_metadata. This permits the designer of a configuration set for a given application to attach configuration to Virtual Nodes and Virtual Networks that is only used at the Application layer. It simplifies correlating resources to application level constructs and avoids the need for complex and fragile mapping data in the Application layer configuration and code.
