### PR TITLE
Add MAC Addresses and Accessors for Virtual Blades and Virtual Nodes on Virtual Networks

### DIFF
--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -49,7 +49,8 @@ from vtds_base.layers.cluster import (
     NodeConnectionBase,
     NodeConnectionSetBase,
     NodeSSHConnectionBase,
-    NodeSSHConnectionSetBase
+    NodeSSHConnectionSetBase,
+    AddressingBase
 )
 
 
@@ -99,6 +100,19 @@ class VirtualNodes(VirtualNodesBase):
 
     def node_ipv4_addr(self, node_class, instance, network_name):
         return self.common.node_ipv4_addr(node_class, instance, network_name)
+
+    def node_class_addressing(self, node_class, network_name):
+        # The connected instances for a node class on a given network
+        # are just all of the instances in the node count if that
+        # network is connected. Otherwise, there are none.
+        connected_instances = list(range(0, self.node_count(node_class)))
+        address_families = self.common.node_address_families(
+            node_class, network_name
+        )
+        return (
+            Addressing(connected_instances, address_families)
+            if address_families is not None else None
+        )
 
     def node_ssh_key_secret(self, node_class):
         return self.common.node_ssh_key_secret(node_class)
@@ -222,6 +236,32 @@ class VirtualNetworks(VirtualNetworksBase):
     def non_cluster_network(self, network_name):
         network = self.__network_by_name(network_name)
         return network.get('non_cluster', False)
+
+    def blade_class_addressing(self, blade_class, network_name):
+        network = self.__network_by_name(network_name)
+        candidates = [
+            candidate.get('blade_instances', [])
+            for candidate in network.get('connected_blades', [])
+            if candidate.get('blade_class', None) == blade_class
+        ]
+        if len(candidates > 1):
+            raise ContextualError(
+                "the vTDS cluster network '%s' configuration is populated "
+                "with more than one list of connected blades for blade "
+                "class '%s'" % (
+                    network_name, blade_class
+                )
+            )
+        connected_instances = candidates[0] if len(candidates) > 0 else []
+        address_families = [
+            {
+                'family': family['family'],
+                'addresses': family['addresses']
+            }
+            for family in network.get('address_families', [])
+            if 'family' in family and 'addresses' in family
+        ]
+        return Addressing(connected_instances, address_families)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -812,3 +852,53 @@ class NodeSSHConnectionSet(NodeSSHConnectionSetBase, NodeConnectionSet):
                     "\n\n    ".join(errors)
                 )
             )
+
+
+class Addressing(AddressingBase):
+    """Addressing information for node and blade classes. This
+    contains all addressing by address family for instances of node
+    class or blade classes as assigned at the cluster level.
+
+    """
+    def __init__(self, connected_instances, address_families):
+        """Constructor
+        """
+        self.connected_instances = connected_instances.copy()
+        # Our local address_families contains, for each address
+        # family, an expanded list of addresses indexed by instance
+        # number. The incoming address_families contains a compressed
+        # list of addresses that lines up with the list of instances
+        # in the object. Expand the list here, filling in None for any
+        # instance numbers that are not in the list of instances.
+        tmp = self.connected_instances.copy()
+        address_families = address_families.copy()  # So we can muck with it...
+        tmp.sort()  # So the highest numbered instance is in [-1]
+        top_instance = tmp[-1]
+        self.families = {
+            family['family']: [
+                family['addresses'].pop(0)
+                if instance in self.connected_instances else None
+                for instance in range(0, top_instance)
+            ]
+            for family in address_families
+            if 'family' in family and 'addresses' in family
+        }
+
+    def address(self, family, instance):
+        return (
+            self.addresses(family)[instance]
+            if instance in self.connected_instances
+            else None
+        )
+
+    def addresses(self, family):
+        return self.families.get(family, [])
+
+    def address_families(self):
+        return [
+            family
+            for family, _ in self.families.items()
+        ]
+
+    def instances(self):
+        return self.connected_instances.copy()

--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -189,18 +189,20 @@ class VirtualNetworks(VirtualNetworksBase):
             )
         return self.networks_by_name[network_name]
 
-    def __l3_config(self, network_name, family):
-        """Get the l3_info block for the specified address family from
+    def __address_family(self, network_name, family):
+        """Get the address_family block for the specified address family from
         the network of the specified name.  If the network doesn't
-        exist raise an exception. If there is no matching l3_info,
+        exist raise an exception. If there is no matching address_family,
         return None.
 
         """
         network = self.__network_by_name(network_name)
         candidates = [
-            l3_info
-            for _, l3_info in network.get('l3_configs', {}).items()
-            if l3_info.get('family', None) == family
+            address_family
+            for _, address_family in network.get(
+                    'address_families', {}
+            ).items()
+            if address_family.get('family', None) == family
         ]
         return candidates[0] if candidates else None
 
@@ -212,10 +214,10 @@ class VirtualNetworks(VirtualNetworksBase):
         return network.get('application_metadata', {})
 
     def ipv4_cidr(self, network_name):
-        l3_config = self.__l3_config(network_name, 'AF_INET')
-        if l3_config is None:
+        address_family = self.__address_family(network_name, 'AF_INET')
+        if address_family is None:
             return None
-        return l3_config.get('cidr', None)
+        return address_family.get('cidr', None)
 
     def non_cluster_network(self, network_name):
         network = self.__network_by_name(network_name)

--- a/vtds_cluster_kvm/private/common.py
+++ b/vtds_cluster_kvm/private/common.py
@@ -510,6 +510,26 @@ class Common:
             )
         return addrs[node_instance]
 
+    def node_address_families(self, node_class, network_name):
+        """Compose an 'address_families' list suitable to use in
+        composing an Addressing object from information found in a
+        given node_class.
+
+        """
+        node_networks = self.node_networks(node_class)
+        if network_name not in node_networks:
+            return None
+        network_interface = self.__get_node_interface(node_class, network_name)
+        addr_info = network_interface.get('addr_info', {})
+        return [
+            {
+                'family': family['family'],
+                'addresses': family['addresses']
+            }
+            for _, family in addr_info.items()
+            if 'family' in family and 'addresses' in family
+        ]
+
     def node_host_blade_connection(
             self, node_class, node_instance, remote_port
     ):

--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -46,7 +46,7 @@ cluster:
     # Virtual Network. Since this is a blade_local network, there is
     # no underlying interconnect. Set this to null.
     blade_interconnect: null
-    l3_configs:
+    address_families:
       ipv4:
         family: AF_INET
         # By default we take a /16 network from a (hopefully) low
@@ -117,7 +117,22 @@ cluster:
       # The name of the Blade Interconnect network underlying this
       # Virtual Network. Set this to null for blade-local networks.
       blade_interconnect: base-interconnect
-      l3_configs:
+      # Connected blades lists the blades that are connected to
+      # the Virtual Network (by default no blade is connected). If
+      # you are going to have a blade provided DHCP server on one
+      # of the blades for this network, that blade (class and
+      # instance) must be a connected blade. For a blade-local
+      # network to exist on a blade, that blade (class and
+      # instance) must be in the set of connected blades.
+      connected_blades:
+        # Connected blades are grouped by blade class and
+        # identified by instance numbers.
+        - blade_class: base-blade
+          blade_instances:
+            - 0
+      # Configuration for things that are specific to a given address
+      # family being used on the network.
+      address_families:
         ipv4:
           family: AF_INET
           cidr: 10.254.0.0/16
@@ -126,25 +141,16 @@ cluster:
             - 10.1.1.1
             - 10.1.1.2
             - 10.1.1.3
-          # Connected blades lists the blades that are connected to
-          # the Virtual Network (by default no blade is connected). If
-          # you are going to have a blade provided DHCP server on one
-          # of the blades for this network, that blade (class and
-          # instance) must be a connected blade. For a blade-local
-          # network to exist on a blade, that blade (class and
-          # instance) must be in the set of connected blades.
+          # Connected blades are assigned IP addresses by blade class
+          # which are indexed by instance number.
           connected_blades:
-            # Connected blades are grouped by blade class and
-            # identified by instance numbers.
             - blade_class: base-blade
-              blade_instances:
-                - 0
               # Each connected blade instance is assigned an IP
               # address on the Virtual Network using the following
               # list of blade IPs matched one-to-one with blade
               # instances. If either list runs out early, no IP
               # address is assigned to remaining blade instances..
-              blade_ips:
+              addresses:
                 - 10.254.0.1
               # If this blade class provides a DHCP server on this
               # Virtual Network, the blade instance where the DHCP


### PR DESCRIPTION
## Summary and Scope

This PR adds MAC address information about connected blades to Virtual Networks at the Cluster layer and accessors to obtain the MAC addresses for Virtual Blades and Virtual Nodes on a given Virtual Network. Among other things, this will permit the creation of CSI seed files for the vShasta Application Layer. It is also expected to be helpful in setting up the network topology for other applications as well.