### PR TITLE
Refactor Blade Level Cluster Deployment to Handle Debian and RedHat Style Distros

### DIFF
--- a/vtds_cluster_kvm/private/__init__.py
+++ b/vtds_cluster_kvm/private/__init__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,11 +30,31 @@ from os.path import (
 )
 CONFIG_DIR = path_join(dirname(__file__), 'config')
 DEPLOY_SCRIPT_NAME = 'deploy_cluster_to_blade.py'
-DEPLOY_SCRIPT_PATH = path_join(
-    dirname(__file__),
-    'scripts',
-    DEPLOY_SCRIPT_NAME
-)
+SCRIPTS_DIR = path_join(dirname(__file__), 'scripts')
+
+DEPLOY_SCRIPT_PATH = path_join(SCRIPTS_DIR, DEPLOY_SCRIPT_NAME)
+CLUSTER_SCRIPT_LIBS = [
+    (
+        path_join(SCRIPTS_DIR, "cluster_common.py"),
+        "/root/cluster_common.py",
+        "cluster_common"
+    ),
+    (
+        path_join(SCRIPTS_DIR, "node_builder.py"),
+        "/root/node_builder.py",
+        "node_builder"
+    ),
+    (
+        path_join(SCRIPTS_DIR, "disk_builder.py"),
+        "/root/disk_builder.py",
+        "disk_builder"
+    ),
+    (
+        path_join(SCRIPTS_DIR, "kickstart.py"),
+        "/root/kickstart.py",
+        "kickstart"
+    ),
+]
 VM_XML_PATH = path_join(
     CONFIG_DIR,
     'virtual_node_template.xml'

--- a/vtds_cluster_kvm/private/cluster.py
+++ b/vtds_cluster_kvm/private/cluster.py
@@ -244,7 +244,7 @@ class Cluster(ClusterAPI):
         ]
         return sum(counts)
 
-    def __add_host_blade_net(self):
+    def __add_host_blade_net(self, config):
         """Merge the blade host networks into the config making sure
         every Virtual Node instance is connected to a blade host
         network and has a static IP address, and making sure that each
@@ -253,9 +253,9 @@ class Cluster(ClusterAPI):
 
         """
         virtual_blades = self.provider_api.get_virtual_blades()
-        node_classes = self.config.get('node_classes', {})
-        networks = self.config.get('networks', {})
-        host_blade_network = self.config.get('host_blade_network', None)
+        node_classes = config.get('node_classes', {})
+        networks = config.get('networks', {})
+        host_blade_network = config.get('host_blade_network', None)
         netname = self.__net_name(host_blade_network)
         hosts = [
             *IPv4Network(self.__get_ipv4_cidr(host_blade_network)).hosts()
@@ -303,6 +303,11 @@ class Cluster(ClusterAPI):
         # Connect all the Virtual Node classes of all classes to the
         # host_blade_network
         for _, node_class in node_classes.items():
+            if node_class.get('pure_base_class', False):
+                # Skip inheritance and installation for pure base
+                # classes since they have no parents, and they aren't
+                # used for deployment.
+                continue
             host_blade_interface = {
                 'delete': False,
                 'cluster_network': netname,
@@ -321,8 +326,8 @@ class Cluster(ClusterAPI):
                 }
             }
             node_class['network_interfaces'][netname] = host_blade_interface
-        self.config['networks'] = networks
-        self.config['node_classes'] = node_classes
+        config['networks'] = networks
+        config['node_classes'] = node_classes
 
     def __expand_node_classes(self, blade_config):
         """Expand the node class inheritance tree found in the
@@ -535,22 +540,24 @@ class Cluster(ClusterAPI):
             self.__set_connected_blade_macs(network, prefix)
 
     def consolidate(self):
-        return
-
-    def prepare(self):
         self.provider_api = self.stack.get_provider_api()
         self.platform_api = self.stack.get_platform_api()
-        self.__add_host_blade_net()
-        blade_config = self.config
-        self.__expand_node_classes(blade_config)
-        self.__set_node_mac_addresses(blade_config)
-        self.__set_all_connected_blade_macs(blade_config)
+        self.__expand_node_classes(self.config)
+        self.__add_host_blade_net(self.config)
+        self.__set_node_mac_addresses(self.config)
+        self.__set_all_connected_blade_macs(self.config)
         networks = self.config.get('networks', {})
-        blade_config['networks'] = {
+        updated_config = self.config
+        updated_config['networks'] = {
             key: self.__add_endpoint_ips(network)
             for key, network in networks.items()
             if not network.get('delete', False)
         }
+        self.config = updated_config
+        return
+
+    def prepare(self):
+        blade_config = self.config
         for _, node_class in self.__get_node_classes(blade_config).items():
             self.__add_xml_template(node_class)
         with open(self.blade_config_path, 'w', encoding='UTF-8') as conf:

--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -140,19 +140,6 @@ cluster:
       # The name of the Blade Interconnect network underlying this
       # Virtual Network. Set this to null for blade-local networks.
       blade_interconnect: base-interconnect
-      # Connected blades lists the blades that are connected to
-      # the Virtual Network (by default no blade is connected). If
-      # you are going to have a blade provided DHCP server on one
-      # of the blades for this network, that blade (class and
-      # instance) must be a connected blade. For a blade-local
-      # network to exist on a blade, that blade (class and
-      # instance) must be in the set of connected blades.
-      connected_blades:
-        # Connected blades are grouped by blade class and
-        # identified by instance numbers.
-        - blade_class: base-blade
-          blade_instances:
-            - 0
       # Configuration for things that are specific to a given address
       # family being used on the network.
       address_families:
@@ -227,15 +214,12 @@ cluster:
       # The 'distro' section contains settings that are specific to the
       # Linux distribution running on the nodes of this class.
       distro:
-        # The pkg_mgmt setting speficies the package manager the Linux
-        # distro uses. Supported values are: 'debian' for debian style
-        # package management (apt and dpkg and such) and 'redhat' for
-        # redhat style package management (RPMs and so forth).
-        pkg_mgmt: debian
-        # The net_mgmt setting specifies what style of network manager
-        # the Linux distro uses. Supported values are 'netplan' or
-        # 'network_manager'
-        net_mgmt: netplan
+        # The family of a distro indicates its closest affiliation in
+        # the Linux distro space. At the moment, what is supported are
+        # Debian style (ubuntu, for example) and RedHat style (CentOs,
+        # or Rocky for example). This tells the deployment script what
+        # installation mechanism is being used for the Virtual Node
+        family: Debian
       # The 'host_blade' settings determine what class of Virtual
       # Blade hosts Virtual Nodes of this class and maximum number of Virtual
       # Nodes of this class that may be hosted per Virtual Blade.
@@ -266,14 +250,47 @@ cluster:
         # The 'boot_disk' block describes the characteristics of the
         # boot disk, including the OS image it should be created from.
         boot_disk:
-          # The 'source_image' field specifies the URL of the OS QCOW
-          # image from which the boot disk for each Virtual Node of
-          # this class should be built.
-          source_image: "http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+          # The 'source_image' field specifies the URL of the OS or
+          # installation media image from which the boot disk for each
+          # Virtual Node of this class should be built.
+          source_image: http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+          # The source checksum allows the source to be signed for
+          # security purposes. The elements of this are the URL from
+          # which the checksum information can be downloaded and the
+          # (optional) algorithm used to produce the checksum.
+          source_checksum:
+            # The URL locates the file containing the checksum
+            url: http://cloud-images.ubuntu.com/focal/current/SHA256SUMS
+            # The algorithm field defaults to SHA256 but can be
+            # provided. If the checksum file identifies the actual
+            # algorithm used, that information is used and this setting
+            # is ignored. In cases where the file does not identify the
+            # algorithm, this is used. Supported options are MD5 and
+            # SHA256.
+            algorithm: SHA256
+          # Media type specifies what the medium of the boot disk is at
+          # download and installation time. Supported media types at the
+          # moment are qcow2 and iso. For a qcow2 image, the disk is
+          # presumed to be installable simply by constructing a Virtual
+          # Node disk image using qemu-img and customizing it using
+          # virt-customize. For an iso image, the image needs to be
+          # booted into a VM and then the resulting disk image (now a
+          # qcow2 image) can be customized.
+          #
+          # The image type interacts with distro.style because, while
+          # Ubuntu and other Debian style distros seem to be available
+          # as live qcow2 images, RedHat style seem to be available only
+          # as iso installation images that need to be booted into and
+          # (generally) installed using kickstart. For RedHat images,
+          # then, the customization is done using and no virt-customize
+          # steps are used. For Ubuntu, if the image is an iso image, it
+          # will be booted to get the qcow, then customized using
+          # virt-customize.
+          media_type: qcow2
           # The 'disk_size_mb' field specifies the size in megabytes
           # (MB -- multiples of 1,000,000 bytes) of the disk and file
           # system to be created from the source image.
-          disk_size_mb: 100000 # 100GB gives us some room to work with
+          disk_size_mb: 50000 # 50GB gives us some room to work with
           # The target device tells libvirt what disk device to attach
           # this disk to when creating the Virtual Node. This needs to
           # be unique among additional disks and the boot disk
@@ -285,9 +302,30 @@ cluster:
             # initialized. If this is null or not provided, the disk
             # will be an empty disk.
             source_image: null
+            # The source checksum block can be used to validate a source
+            # image. See the 'boot_disk' source information for more
+            # details.
+            source_checksum: {}
+            # The source checksum allows the source to be signed for
+            # security purposes. None specified here because no image
+            # was specified. If one were specified it would be a URL to
+            # a checksum file generated by the provider of the source
+            # image.
+            source_checksum: null
+            # The source checksum algorithm defaults to SHA256 but can
+            # be specified here. If the checksum file indicates a the
+            # actual algorithm used, that information is used and this
+            # setting is ignored. In cases where the file does not
+            # identify the algorithm, this is used. Supported options
+            # are MD5 and SHA256.
+            source_checksum_algorithm: SHA256
+            # Media type specifies what medium the disk image
+            # is. For non-boot disks, the only medium that is currently
+            # supported is qcow2.
+            media_type: qcow2
             # The 'disk_size_mb' field specifies the size in megabytes
             # (MB -- multiples of 1,000,000 bytes) of the disk.
-            disk_size_mb: 100000 # 100GB
+            disk_size_mb: 50000 # 50GB
             # The target device tells libvirt what disk device to attach
             # this disk to when creating the Virtual Node. This needs to
             # be unique among additional disks and the boot disk
@@ -431,9 +469,20 @@ cluster:
       # Rocky Linux (which is RedHat based)
       parent_class: ubuntu_24_04_node
       distro:
-        pkg_mgmt: redhat
-        net_mgmt: network_manager
+        family: RedHat
       virtual_machine:
         boot_disk:
           # The distro is Rocky, so use that instead of Ubuntu.
-          source_image: https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2
+          source_image: https://dl.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9-latest-x86_64-minimal.iso
+          source_checksum:
+            # The URL locates the file containing the checksum
+            url: |
+              https://dl.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9-latest-x86_64-minimal.iso.CHECKSUM
+            # The algorithm field defaults to SHA256 but can be
+            # provided. If the checksum file identifies the actual
+            # algorithm used, that information is used and this setting
+            # is ignored. In cases where the file does not identify the
+            # algorithm, this is used. Supported options are MD5 and
+            # SHA256.
+            algorithm: SHA256
+          media_type: iso

--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -224,6 +224,18 @@ cluster:
       # The 'node_count' field indicates how many nodes of this type
       # to instantiate on the cluster.
       node_count: 0
+      # The 'distro' section contains settings that are specific to the
+      # Linux distribution running on the nodes of this class.
+      distro:
+        # The pkg_mgmt setting speficies the package manager the Linux
+        # distro uses. Supported values are: 'debian' for debian style
+        # package management (apt and dpkg and such) and 'redhat' for
+        # redhat style package management (RPMs and so forth).
+        pkg_mgmt: debian
+        # The net_mgmt setting specifies what style of network manager
+        # the Linux distro uses. Supported values are 'netplan' or
+        # 'network_manager'
+        net_mgmt: netplan
       # The 'host_blade' settings determine what class of Virtual
       # Blade hosts Virtual Nodes of this class and maximum number of Virtual
       # Nodes of this class that may be hosted per Virtual Blade.
@@ -261,7 +273,7 @@ cluster:
           # The 'disk_size_mb' field specifies the size in megabytes
           # (MB -- multiples of 1,000,000 bytes) of the disk and file
           # system to be created from the source image.
-          disk_size_mb: 10000 # 10GB
+          disk_size_mb: 100000 # 100GB gives us some room to work with
           # The target device tells libvirt what disk device to attach
           # this disk to when creating the Virtual Node. This needs to
           # be unique among additional disks and the boot disk
@@ -413,3 +425,15 @@ cluster:
       # caution because it has the power to entangle a given vTDS stack
       # and make it non-portable.
       application_metadata: {}
+    rocky_linux_node:
+      pure_base_class: true
+      # Use the ubuntu_24_04_node class as a base class and tweak it for
+      # Rocky Linux (which is RedHat based)
+      parent_class: ubuntu_24_04_node
+      distro:
+        pkg_mgmt: redhat
+        net_mgmt: network_manager
+      virtual_machine:
+        boot_disk:
+          # The distro is Rocky, so use that instead of Ubuntu.
+          source_image: https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2

--- a/vtds_cluster_kvm/private/config/virtual_node_template.xml
+++ b/vtds_cluster_kvm/private/config/virtual_node_template.xml
@@ -56,13 +56,13 @@
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type="file" device="disk">
       <driver name="qemu" type="qcow2"/>
-      <source file="{{ boot_disk.file_name }}"/>
+      <source file="{{ boot_disk.file_path }}"/>
       <target dev="{{ boot_disk.target_device }}" bus="virtio"/>
     </disk>
     {% for extra_disk in extra_disks %}
     <disk type="file" device="disk">
       <driver name="qemu" type="qcow2"/>
-      <source file="{{ extra_disk.file_name }}"/>
+      <source file="{{ extra_disk.file_path }}"/>
       <target dev="{{ extra_disk.target_device }}" bus="virtio"/>
     </disk>
     {% endfor %}

--- a/vtds_cluster_kvm/private/scripts/cluster_common.py
+++ b/vtds_cluster_kvm/private/scripts/cluster_common.py
@@ -1,0 +1,735 @@
+#! python
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# pylint: disable='consider-using-f-string'
+"""Common routines and classes used to support cluster deployment.
+
+"""
+import os
+from os.path import join as path_join
+import sys
+from subprocess import (
+    Popen,
+    TimeoutExpired,
+    PIPE
+)
+import json
+import yaml
+
+
+class ContextualError(Exception):
+    """Exception to report failures seen and contextualized within the
+    application.
+
+    """
+
+
+class UsageError(Exception):  # pylint: disable=too-few-public-methods
+    """Exception to report usage errors
+
+    """
+
+
+def write_out(string):
+    """Write an arbitrary string on stdout and make sure it is
+    flushed.
+
+    """
+    sys.stdout.write(string)
+    sys.stdout.flush()
+
+
+def write_err(string):
+    """Write an arbitrary string on stderr and make sure it is
+    flushed.
+
+    """
+    sys.stderr.write(string)
+    sys.stderr.flush()
+
+
+def usage(usage_msg, err=None):
+    """Print a usage message and exit with an error status.
+
+    """
+    if err:
+        write_err("ERROR: %s\n" % err)
+    write_err("%s\n" % usage_msg)
+    sys.exit(1)
+
+
+def error_msg(msg):
+    """Format an error message and print it to stderr.
+
+    """
+    write_err("ERROR: %s\n" % msg)
+
+
+def warning_msg(msg):
+    """Format a warning and print it to stderr.
+
+    """
+    write_err("WARNING: %s\n" % msg)
+
+
+def info_msg(msg):
+    """Format an informational message and print it to stderr.
+
+    """
+    write_err("INFO: %s\n" % msg)
+
+
+def run_cmd(cmd, args, stdin=sys.stdin, check=True, timeout=None):
+    """Run a command with output on stdout and errors on stderr
+
+    """
+    exitval = 0
+    try:
+        with Popen(
+                [cmd, *args],
+                stdin=stdin, stdout=sys.stdout, stderr=sys.stderr
+        ) as command:
+            time = 0
+            signaled = False
+            while True:
+                try:
+                    exitval = command.wait(timeout=5)
+                except TimeoutExpired:
+                    time += 5
+                    if timeout and time > timeout:
+                        if not signaled:
+                            # First try to terminate the process
+                            command.terminate()
+                            continue
+                        command.kill()
+                        print()
+                        # pylint: disable=raise-missing-from
+                        raise ContextualError(
+                            "'%s' timed out and did not terminate "
+                            "as expected after %d seconds" % (
+                                " ".join([cmd, *args]),
+                                time
+                            )
+                        )
+                    continue
+                # Didn't time out, so the wait is done.
+                break
+            print()
+    except OSError as err:
+        raise ContextualError(
+            "executing '%s' failed - %s" % (
+                " ".join([cmd, *args]),
+                str(err)
+            )
+        ) from err
+    if exitval != 0 and check:
+        fmt = (
+            "command '%s' failed"
+            if not signaled
+            else "command '%s' timed out and was killed"
+        )
+        raise ContextualError(fmt % " ".join([cmd, *args]))
+    return exitval
+
+
+def read_config(config_file):
+    """Read in the specified YAML configuration file for this blade
+    and return the parsed data.
+
+    """
+    try:
+        with open(config_file, 'r', encoding='UTF-8') as config:
+            return yaml.safe_load(config)
+    except OSError as err:
+        raise ContextualError(
+            "failed to load blade configuration file '%s' - %s" % (
+                config_file,
+                str(err)
+            )
+        ) from err
+
+
+def if_network(interface):
+    """Retrieve the network name attached to an interface, raise an
+    exception if there is none.
+
+    """
+    try:
+        return interface['cluster_network']
+    except KeyError as err:
+        raise ContextualError(
+            "configuration error: interface '%s' doesn't "
+            "identify its connected Virtual Network" % str(interface)
+        ) from err
+
+
+def net_name(network):
+    """Retrieve the network name of a network, raise an exception if
+    there is none.
+
+    """
+    try:
+        return network['network_name']
+    except KeyError as err:
+        raise ContextualError(
+            "configuration error: network %s has no "
+            "network name" % str(network)
+        ) from err
+
+
+def blade_ipv4_ifname(network):
+    """Get the name of the interface on the blade where DHCP is
+    served for this interface (if any) and return it. Return None
+    if there is nothing configured for that.
+
+    """
+    return network.get('devices', {}).get('local', {}).get('interface', None)
+
+
+def blade_ipv4_cidr(network):
+    """Get the IPv4 CIDR of the interface on the blade where DHCP is
+    served for this interface (if any) and return it. Return None if
+    there is nothing configured for that.
+
+    """
+    return network.get('devices', {}).get('local', {}).get('interface', None)
+
+
+def connected_blade_instances(network, blade_class):
+    """Get the list of conencted blade instance numbers for a given
+    network and blade class.
+
+    """
+    return [
+        int(blade_instance)
+        for blade in network.get('connected_blades', [])
+        if blade.get('blade_class', None) == blade_class
+        for blade_instance in blade.get('blade_instances', [])
+    ]
+
+
+def connected_blade_ipv4s(network, blade_class):
+    """Get the list of conencted blade IP addresses for a given
+    network and blade class.
+
+    """
+    address_family = find_address_family(network, 'AF_INET')
+    return [
+        ipv4_addr
+        for blade in address_family.get('connected_blades', [])
+        if blade.get('blade_class', None) == blade_class
+        for ipv4_addr in blade.get('addresses', [])
+    ]
+
+
+def connected_blade_macs(network, blade_class):
+    """Get the list of conencted blade IP addresses for a given
+    network and blade class.
+
+    """
+    address_family = find_address_family(network, 'AF_LINK')
+    return [
+        mac
+        for blade in address_family.get('connected_blades', [])
+        if blade.get('blade_class', None) == blade_class
+        for mac in blade.get('blade_macs', [])
+    ]
+
+
+def network_blade_connected(network, blade_class, blade_instance):
+    """Determine whether the specified network is connected to the
+    specified instance of the specified blade class. If it is, return
+    True otherwise False.
+
+    """
+    return blade_instance in connected_blade_instances(network, blade_class)
+
+
+def network_blade_ipv4(network, blade_class, blade_instance):
+    """Return the IPv4 address (if any) of the given instance of the
+    given blade class on the given network. If no such address is
+    found, return None.
+
+    """
+    instances = connected_blade_instances(network, blade_class)
+    ipv4s = connected_blade_ipv4s(network, blade_class)
+    count = len(instances) if len(instances) <= len(ipv4s) else len(ipv4s)
+    candidates = [
+        ipv4s[i] for i in range(0, count)
+        if blade_instance == instances[i]
+    ]
+    return candidates[0] if candidates else None
+
+
+def network_ipv4_gateway(network):
+    """Return the network IPv4 gateway address if there is one for the
+    specified network. If no gateway is configured, return None.
+
+    """
+    return find_address_family(network, 'AF_INET').get('gateway', None)
+
+
+def is_nat_router(network, blade_class, blade_instance):
+    """Determine whether the specified instance of the specified
+    virtual blade class is the NAT router for the specified virtual
+    network (the NAT router for a virtual network is whatever blade
+    hosts the gateway for that network).
+
+    """
+    blade_ipv4 = network_blade_ipv4(network, blade_class, blade_instance)
+    gateway = network_ipv4_gateway(network)
+    return blade_ipv4 and gateway and blade_ipv4 == gateway
+
+
+def is_dhcp_server(network, blade_class, blade_instance):
+    """Determine whether the specified instance of the specified
+    virtual blade class is the NAT router for the specified virtual
+    network (the NAT router for a virtual network is whatever blade
+    hosts the gateway for that network).
+
+    """
+    address_family = find_address_family(network, 'AF_INET')
+    candidates = [
+        blade
+        for blade in address_family.get('connected_blades', [])
+        if blade.get('blade_class', None) == blade_class and
+        blade.get('dhcp_server_instance', None) == blade_instance
+    ]
+    return len(candidates) > 0
+
+
+def network_connected(network, node_classes):
+    """Determine whether the specified network is connected to an
+    interface in any of the specified node classes. If it is return
+    True otherwise False.
+
+    """
+    interface_connections = [
+        interface['cluster_network']
+        for node_class in node_classes
+        if 'network_interfaces' in node_class
+        for _, interface in node_class['network_interfaces'].items()
+        if 'cluster_network' in interface
+    ]
+    return net_name(network) in interface_connections
+
+
+def node_addrs(network_interface, address_family):
+    """Get the list of addresses configured for the named address
+    family in the supplied netowrk interface taken from a node class
+
+    """
+    try:
+        addr_info = network_interface['addr_info']
+    except KeyError as err:
+        raise ContextualError(
+            "cofiguration error: network interface %s has no 'addr_info' "
+            "section" % str(network_interface)
+        ) from err
+    addrs = []
+    for _, info in addr_info.items():
+        if info.get('family', None) == address_family:
+            if addrs:
+                raise ContextualError(
+                    "configuration error: more than one '%s' addr_info "
+                    "block found in "
+                    "network interface %s" % (
+                        address_family, str(network_interface)
+                    )
+                )
+            addrs += info.get('addresses', [])
+    return addrs
+
+
+def node_mac_addrs(network_interface):
+    """Get the list of node MAC addresses from the provided network
+    interface information taken from a node class.
+
+    """
+    return node_addrs(network_interface, 'AF_PACKET')
+
+
+def node_ipv4_addrs(network_interface):
+    """Get the list of node IPv4 addresses from the provided network
+    interface information taken from a node class.
+
+    """
+    return node_addrs(network_interface, 'AF_INET')
+
+
+def node_ipv4(node_class, node_instance, network):
+    """Get the IPv4 address of this node on the named network if
+       this node's instance of its node class has a static or
+       reserved address on that network. Otherwise return None.
+
+        """
+    node_name = compute_node_name(node_class, node_instance)
+    interface_candidates = [
+        interface
+        for _, interface in node_class
+        .get('network_interfaces', {}).items()
+        if interface.get('cluster_network', None) == network
+    ]
+    if not interface_candidates:
+        raise ContextualError(
+            "there is no network interface for network '%s' in %s" % (
+                network, node_name
+            )
+        )
+    if len(interface_candidates) > 1:
+        raise ContextualError(
+            "there is more than one network interface for "
+            "network '%s' in %s" % (
+                network, node_name
+            )
+        )
+    interface = interface_candidates[0]
+    addr_info = find_addr_info(interface, 'AF_INET')
+    addresses = addr_info.get('addresses', [])
+    return (
+        addresses[node_instance]
+        if len(addresses) > node_instance
+        else None
+    )
+
+
+def find_addr_info(interface, family):
+    """Find the address information for the specified address family
+    ('family') in the provided node class interface configuration
+    ('interface').
+
+    """
+    addr_infos = [
+        addr_info
+        for _, addr_info in interface.get('addr_info', {}).items()
+        if addr_info.get('family', None) == family
+    ]
+    if len(addr_infos) > 1:
+        netname = interface['cluster_network']
+        raise ContextualError(
+            "configuration error: the interface for network '%s' in a "
+            "node class has more than one '%s' 'addr_info' block: %s" % (
+                netname,
+                family,
+                str(interface)
+            )
+        )
+    if not addr_infos:
+        raise ContextualError(
+            "configuration error: the interface for network '%s' in the "
+            "node class has no '%s' 'addr_info' block: %s" % (
+                netname,
+                family,
+                str(interface)
+            )
+        )
+    return addr_infos[0]
+
+
+def find_address_family(network, family):
+    """Find the L3 configuration for the specified address family
+    ('family') in the provided network configuration ('network').
+
+    """
+    netname = net_name(network)
+    # There should be exactly one 'address_family' block in the network
+    # with the specified family.
+    address_families = [
+        address_family
+        for _, address_family in network.get('address_families', {}).items()
+        if address_family.get('family', None) == family
+    ]
+    if len(address_families) > 1:
+        raise ContextualError(
+            "configuration error: the Virtual Network named '%s' has more "
+            "than one %s 'address_family' block." % (netname, family)
+        )
+    if not address_families:
+        raise ContextualError(
+            "configuration error: the Virtual Network named '%s' has "
+            "no %s 'address_family' block." % (netname, family)
+        )
+    return address_families[0]
+
+
+def network_length(address_family, netname):
+    """Given an address_family ('address_family') from a network named
+    'netname' return the network length from its 'cidr' element.
+
+    """
+    if 'cidr' not in address_family:
+        raise ContextualError(
+            "configuration error: the AF_INET 'address_family' block for the "
+            "network named '%s' has no 'cidr' configured" % netname
+        )
+    if '/' not in address_family['cidr']:
+        raise ContextualError(
+            "configuration error: the AF_INET 'cidr' value '%s' for the "
+            "network named '%s' is malformed" % (
+                address_family['cidr'], netname
+            )
+        )
+    return address_family['cidr'].split('/')[1]
+
+
+def find_blade_cidr(network, blade_class, blade_instance):
+    """Find the IPv4 address/CIDR to use on the network interface for
+    a specified network. The 'network' argument describes the network
+    of interest, 'blade_class' and 'blade_instance' identify the blade
+    we are running on. If there is no IPv4 address for this blade,
+    then return None.
+
+    """
+    address_family = find_address_family(network, "AF_INET")
+    blade_ip = network_blade_ipv4(network, blade_class, blade_instance)
+    return (
+        '/'.join((blade_ip, network_length(address_family, net_name(network))))
+        if blade_ip is not None else None
+    )
+
+
+def network_layer_2_name(network):
+    """Get or construct the layer 2 interface name for the network
+    configuration found in 'network'.
+
+    """
+    network_name = net_name(network)
+    return network.get('devices', {}).get('layer_2', network_name)
+
+
+def network_bridge_name(network):
+    """Get or construct the bridge name for the network configuration
+    found in 'network'.
+
+    """
+    layer_2_name = network_layer_2_name(network)
+    return network.get('devices', {}).get(
+        'bridge_name', "br-%s" % layer_2_name
+    )
+
+
+def node_connected_networks(node_class, networks):
+    """Given a node class and a list of networks return a dictionary
+    of networks that are connected to that node class indexed by
+    network name.
+
+    """
+    if_nets = [
+        interface.get('cluster_network', "")
+        for _, interface in node_class.get('network_interfaces', {}).items()
+    ]
+    return {
+        net_name(network): network
+        for _, network in networks.items()
+        if net_name(network) in if_nets
+    }
+
+
+def instance_range(node_class, blade_instance):
+    """Compute a range of Virtual Nodes of a given node class
+    ('node_class') that belong on a given Virtual Blade instance
+    ('blade_instance') based on the number of Virtual Nodes of that
+    class to be deployed and the number of Virtual Nodes of that class
+    that fit on each blade. Return the range as a tuple.
+
+    """
+    blade_instance = int(blade_instance)  # coerce to int for local use
+    node_count = int(node_class.get('node_count'))
+    capacity = int(
+        node_class
+        .get('host_blade', {})
+        .get('instance_capacity', 1)
+    )
+    start = blade_instance * capacity
+    start = start if start < node_count else node_count
+    end = (blade_instance * capacity) + capacity
+    end = end if end < node_count else node_count
+    return (start, end)
+
+
+def open_safe(path, flags):
+    """Safely open a file with a mode that only permits reads and
+    writes by owner. This is used as an 'opener' in cases where the
+    file needs protecting.
+
+    """
+    return os.open(path, flags, 0o600)
+
+
+def install_blade_ssh_keys(key_dir):
+    """Copy the blade SSH keys into place from the uploaded key
+    directory. The public key is already authorized, so no need to do
+    anything to authorized keys.
+
+    """
+    priv = 'id_rsa'
+    pub = 'id_rsa.pub'
+    ssh_dir = path_join(os.sep, 'root', '.ssh')
+    with open(path_join(key_dir, priv), 'r', encoding='UTF-8') as key_in, \
+         open(path_join(ssh_dir, priv), 'w',
+              encoding='UTF-8', opener=open_safe) as key_out:
+        key_out.write(key_in.read())
+    with open(path_join(key_dir, pub), 'r', encoding='UTF-8') as key_in, \
+         open(path_join(ssh_dir, pub), 'w', encoding='UTF-8') as key_out:
+        key_out.write(key_in.read())
+    # Remove the known_hosts file, since it shouldn't have anything
+    # useful in it anyway and it is going to have the wrong keys for
+    # the Virtual Nodes if it has anything.
+    run_cmd('rm', ['-f', path_join(ssh_dir, 'known_hosts')])
+
+
+def get_blade_interface_data():
+    """Collect the interface data from the blade as a data structure.
+
+    """
+    with Popen(
+        ['ip', '-d', '--json', 'addr'],
+        stdout=PIPE,
+        stderr=PIPE
+    ) as cmd:
+        return json.loads(cmd.stdout.read())
+
+
+def find_interconnect_interface():
+    """Find the interface that connects to the blade interconnect on
+    this blade (i.e. not a tunnel, not a bridge, not a peer, but a
+    straight up interface and return its name).
+
+    """
+    if_data = get_blade_interface_data()
+    # Look for interfaces that are 'ether' and not qualified by any other
+    # stuff like bridging or tunelling or whatever.
+    candidates = [
+        interface['ifname']
+        for interface in if_data
+        if interface.get('link_type', '') == 'ether' and
+        interface.get('linkinfo', None) is None
+    ]
+    if len(candidates) > 1:
+        # We should only have one candidate, catch the case where there
+        # are more and error out on them. If this is not a valid assumption
+        # we may, some day, need to go further with this, but for now it
+        # should suffice.
+        raise ContextualError(
+            "internal error: there appears to be more than one pure ethernet "
+            "interface on this Virtual Blade: %s" % str(candidates)
+        )
+    if not candidates:
+        # We should have a candidate. If not there is a problem.
+        raise ContextualError(
+            "internal error: there does not appear to be any pure ethernet "
+            "interface on this Virtual Blade: %s" % str(if_data)
+        )
+    return candidates[0]
+
+
+def find_mtu(link_name):
+    """Given the name of a network link (interface) return the MTU of
+    that link.
+
+    """
+    if_data = get_blade_interface_data()
+    candidates = [
+        link
+        for link in if_data
+        if link.get('ifname', "") == link_name
+    ]
+    if not candidates:
+        raise ContextualError(
+            "internal error: no link named '%s' found in blade interfaces "
+            "cannot retrieve the MTU - %s" % (link_name, if_data)
+        )
+    if len(candidates) > 1:
+        raise ContextualError(
+            "internal error: more than one link named '%s' found in blade "
+            "interfaces cannot discern the MTU - %s" % (
+                link_name, str(if_data)
+            )
+        )
+    mtu = candidates[0].get('mtu', None)
+    if mtu is None:
+        raise ContextualError(
+            "internal error: link '%s' has no MTU "
+            "specified - %s" % str(candidates[0])
+        )
+    return mtu
+
+
+def prepare_nat():
+    """Prepare the blade for installation of NAT rules (load kernel
+    modules and clear out any stale NAT rules).
+
+    """
+    # We are going to add NAT, so Load the canonically necessary
+    # kernel modules...
+    run_cmd('modprobe', ['ip_tables'])
+    run_cmd('modprobe', ['ip_conntrack'])
+    run_cmd('modprobe', ['ip_conntrack_irc'])
+    run_cmd('modprobe', ['ip_conntrack_ftp'])
+    # Clear out any old NAT rules...
+    run_cmd('iptables', ['-t', 'nat', '-F'])
+
+
+def install_nat_rule(network):
+    """Run through the networks for which this blade is a DHCP server
+    and, if this blade is also the configured gateway for the network,
+    add a NAT rule for this network on the blade to masquerade traffic
+    from that network to external IPs.
+
+    """
+    dest_if = find_interconnect_interface()
+    cidr = find_address_family(network, 'AF_INET')['cidr']
+    run_cmd(
+        'iptables',
+        [
+            '-t', 'nat', '-A', 'POSTROUTING', '-s', cidr,
+            '-o', dest_if, '-j', 'MASQUERADE'
+        ]
+    )
+
+
+def compute_node_name(node_class, node_instance):
+    """Based on the naming information in the node_class compose a
+       node name for this instance of the node_class and return it as
+       a string.
+
+       Since all of the magic to make sure node names are set up has
+       already been done by the preparation of the config, just use
+       the hostnames that are there. No need to be fancy about it.
+
+    """
+    return node_class['node_naming']['node_names'][node_instance]
+
+
+def compute_hostname(node_class, node_instance):
+    """Based on the naming information in the node_class compose a
+       host name for this instance of the node_class and return it as
+       a string.
+
+       Since all of the magic to make sure hostnames are set up has
+       already been done by the preparation of the config, just use
+       the hostnames that are there. No need to be fancy about it.
+
+    """
+    return node_class['host_naming']['hostnames'][node_instance]

--- a/vtds_cluster_kvm/private/scripts/deploy_cluster_to_blade.py
+++ b/vtds_cluster_kvm/private/scripts/deploy_cluster_to_blade.py
@@ -1040,8 +1040,8 @@ class VirtualNode:
                     self.class_name, str(self.node_class)
                 )
             ) from err
-        self.pkg_mgmt = node_class.get('pkg_mgmt', 'debian')
-        self.net_mgmt = node_class.get('net_mgmt', 'netplan')
+        self.pkg_mgmt = node_class.get('distro', {}).get('pkg_mgmt', 'debian')
+        self.net_mgmt = node_class.get('distro', {}).get('net_mgmt', 'netplan')
         self.context = self.__compose()
 
     def __compute_node_name(self):

--- a/vtds_cluster_kvm/private/scripts/disk_builder.py
+++ b/vtds_cluster_kvm/private/scripts/disk_builder.py
@@ -1,0 +1,545 @@
+#! python
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# pylint: disable='consider-using-f-string'
+"""Base class and implementations of Disk Builder classes to support
+deploying various combinations of Linux distributiuon and Disk Media
+types.
+
+"""
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+import os
+from os import (
+    makedirs,
+    remove as remove_file,
+    rmdir
+)
+from os.path import (
+    exists,
+    join as path_join
+)
+from shutil import rmtree
+from tempfile import (
+    NamedTemporaryFile,
+    mkdtemp
+)
+from time import sleep
+import yaml
+
+from cluster_common import (
+    ContextualError,
+    run_cmd,
+    node_mac_addrs,
+    compute_node_name,
+    compute_hostname,
+    find_addr_info,
+    find_address_family,
+    network_length,
+    network_bridge_name,
+    open_safe,
+    find_mtu,
+    node_connected_networks,
+    info_msg
+)
+
+from kickstart import KickstartConfig
+
+
+class DiskBuilder(metaclass=ABCMeta):
+    """Base class for Disk Builder classes
+
+    """
+    def __init__(self, config, node_class, node_instance, root_passwd):
+        """Constructor
+
+        """
+        self.config = config
+        self.node_class = node_class
+        self.node_instance = node_instance
+        self.root_passwd = root_passwd
+        self.networks = node_connected_networks(node_class, config['networks'])
+        self.host_name = compute_hostname(node_class, node_instance)
+        # Set up to be ready to make the boot disk
+        self.nodeclass_dir = path_join(
+            os.sep, 'var', 'local', 'vtds', self.node_class['class_name']
+        )
+        node_name = compute_node_name(node_class, node_instance)
+        self.host_dir = path_join(self.nodeclass_dir, node_name)
+        makedirs(self.host_dir, mode=0o755, exist_ok=True)
+        virtual_machine = node_class.get('virtual_machine', {})
+        try:
+            self.disk_config = virtual_machine['boot_disk']
+        except KeyError as err:
+            raise ContextualError(
+                "configuration error: Virtual Node class '%s' "
+                "'virtual_machine' section "
+                "does not contain a 'boot_disk' "
+                "section: %s" % (
+                    self.node_class['class_name'],
+                    str(self.node_class)
+                )
+            ) from err
+        self.boot_disk_path = path_join(self.host_dir, "boot_disk.img")
+
+    @staticmethod
+    def _retrieve_image(url, dest):
+        """Retrieve a disk image from a URL ('url') and write it the
+        file named in 'dest'.
+
+        """
+        # Using curl here instead of writing a requests library
+        # operation because it is simpler and just about as fast and
+        # the error handling is covered. If the destination file
+        # already exists, simply return. If retrieval fails, remove
+        # any partial destination file that might have been created.
+        dest = dest.strip()
+        url = url.strip()
+        retry = 0
+        while not exists(dest):
+            try:
+                run_cmd('curl', ['-o', dest, '-s', url])
+            except Exception as err:
+                if exists(dest):
+                    remove_file(dest)
+                # This does not always work on the first try...
+                retry += 1
+                if retry < 20:
+                    info_msg(
+                        "retrieving '%s' failed, retrying [%d]..." % (
+                            url, retry,
+                        )
+                    )
+                    sleep(30)
+                    continue
+                raise err
+
+    def _make_extra_disks(self):
+        """Create all of the extra disk images for this Virtual Node
+        using the information in from the Node Class and return the
+        template description of the list of disks.
+
+        Only qcow2 images are supported for extra disk content
+        images. If no content is needed, then there will be no image
+        specified and we make an empty disk.
+
+        """
+        virtual_machine = self.node_class.get('virtual_machine', {})
+        extra_disks = virtual_machine.get('additional_disks', {})
+        return [
+            self._make_qcow_disk(
+                path_join(self.host_dir, "%s.img" % disk_name),
+                extra_disk,
+                (
+                    path_join(self.nodeclass_dir, "%s.qcow" % disk_name)
+                    if extra_disk.get('source_image', None) else
+                    None
+                )
+            )
+            for disk_name, extra_disk in extra_disks.items()
+        ]
+
+    @staticmethod
+    # Take the pylint line out when we start using partitions
+    #
+    # pylint: disable=unused-argument
+    def _make_qcow_image(name, size, source_image_name, partitions):
+        """Build a qcow2 disk image in a file named 'name'. If 'size'
+        is not None make sure the resulting disk image is 'size' bytes
+        long. If 'source_image_name' is not None, use the source image
+        in the named file. If 'partitions' is specified, partition the
+        disk accordingly.
+
+        """
+        run_cmd(
+            'rm',
+            ['-f', name]
+        )
+        # pylint: disable=fixme
+        # TODO implement partitioning
+        source_options = (
+            ['-b', source_image_name, '-F', 'qcow2']
+            if source_image_name
+            else []
+        )
+        size_args = ['%sM' % size] if size else []
+        run_cmd(
+            'qemu-img',
+            ['create', *source_options, '-f', 'qcow2', name, *size_args]
+        )
+        run_cmd(
+            'chown',
+            ['libvirt-qemu:kvm', name]
+        )
+
+    def _make_qcow_disk(self, name, disk_config, source_image_name=None):
+        """Given the filename ('name') to store the boot disk file,
+        the disk configuration ('disk_config') and the path to the
+        place to store the source image ('source_image_name'),
+        construct a disk for use with the Virtual Node and return its
+        description.
+
+        """
+        image_url = disk_config.get('source_image', None)
+        partitions = disk_config.get('partitions', {})
+        size = disk_config.get('disk_size_mb', None)
+        target_dev = disk_config.get('target_device', None)
+        if not target_dev:
+            raise ContextualError(
+                "configuration error: disk '%s' has no target device "
+                "configured: %s" % (name, str(disk_config))
+            )
+        if partitions and image_url:
+            raise ContextualError(
+                "configuration error: Virtual Node class '%s' "
+                "disk configuration "
+                "declares both a non-empty 'source_image' "
+                "URL ('%s') and a non-empty partition list, "
+                "must choose one or the other: %s" % (
+                    self.node_class['class_name'],
+                    image_url,
+                    str(disk_config)
+                )
+            )
+        if not image_url and not partitions and not size:
+            raise ContextualError(
+                "configuration error: Virtual Node class '%s' disk "
+                "configuration must declare at "
+                "at least one of 'disk_size_mb', 'source_image' "
+                "or 'partitions': %s" % (
+                    self.node_class['class_name'],
+                    str(disk_config)
+                )
+            )
+        if image_url and not source_image_name:
+            raise ContextualError(
+                "internal error: no source image name supplied when making "
+                "a disk with a source image URL"
+            )
+        if image_url:
+            self._retrieve_image(image_url, source_image_name)
+        self._make_qcow_image(name, size, source_image_name, partitions)
+        return {
+            'file_path': name,
+            'target_device': target_dev,
+        }
+
+    @abstractmethod
+    def build_boot_disk(self):
+        """Build the boot disk for the node class this disk builder
+        builds for.
+
+        """
+
+    def build_extra_disks(self):
+        """Build the extra disks for the node class.
+
+        """
+        return self._make_extra_disks()
+
+
+class DebianQCOWDisk(DiskBuilder):
+    """Implementation of a disk builder for building Debian root file
+    systems using QCOW2 images.
+
+    """
+    def __init__(self, config, node_class, node_instance, root_passwd):
+        """Constructor
+
+        """
+        self.__doc__ = DiskBuilder.__doc__
+        DiskBuilder.__init__(
+            self, config, node_class, node_instance, root_passwd
+        )
+
+    def __make_boot_disk(self):
+        """Create a boot disk image for this Virtual Node using the
+        information from the Node Class and return the template
+        description of the disk.
+
+        """
+        source_image_name = path_join(
+            self.nodeclass_dir, 'boot-img-source.qcow'
+        )
+        return self._make_qcow_disk(
+            self.boot_disk_path, self.disk_config, source_image_name
+        )
+
+    def __netplan_if(self, interface):
+        """Compose an interface block for the netplan configuration
+
+        """
+        network = self.networks[interface['cluster_network']]
+        node_instance = int(self.node_instance)
+        ipv4_info = find_addr_info(interface, "AF_INET")
+        address_family = find_address_family(network, "AF_INET")
+        addresses = ipv4_info.get('addresses', [])
+        static_addr = node_instance < len(addresses)
+        net_length = network_length(
+            address_family, interface['cluster_network']
+        )
+        return {
+            'addresses': (
+                [
+                    '/'.join([addresses[self.node_instance], net_length])
+                ]
+                if static_addr else []
+            ),
+            'dhcp6': False,
+            'dhcp4': (
+                ipv4_info['mode'] in ['dynamic', 'reserved'] or
+                node_instance >= len(addresses)
+            ),
+            'mtu': find_mtu(network_bridge_name(network)),
+            'match': {
+                'macaddress': node_mac_addrs(interface)[node_instance]
+            }
+        }
+
+    def __configure_netplan(self):
+        """Configure netplan for the Virtual Node with all of the
+        available network interfaces that are defined for the node.
+
+        """
+        if not self.boot_disk_path or not exists(self.boot_disk_path):
+            raise ContextualError(
+                "internal error: __configure_netplan run before the "
+                "boot disk image was created"
+            )
+        netplan = {
+            'network': {
+                'version': "2",
+                'renderer': 'networkd',
+                'ethernets': {
+                    interface['cluster_network']: self.__netplan_if(interface)
+                    for _, interface in self.node_class.get(
+                            'network_interfaces', {}
+                    ).items()
+                }
+            }
+        }
+        with NamedTemporaryFile(mode='w', encoding='UTF-8') as tmpfile:
+            yaml.safe_dump(netplan, tmpfile)
+            tmpfile.flush()
+            run_cmd(
+                'virt-customize',
+                [
+                    '-a', self.boot_disk_path,
+                    '--upload',
+                    "%s:/etc/netplan/10-vtds-ethernets.yaml" % tmpfile.name
+                ]
+            )
+
+    def __reconfigure_ssh(self):
+        """Run 'dpkg-recofigure openssh-server' on the root disk so
+        that the SSH servers will have host keys. Also, install root
+        SSH keys and authorizations.
+
+        """
+        actions = [
+            '--run-command', 'dpkg-reconfigure openssh-server',
+            '--copy-in', '/root/.ssh:/root',
+            '--hostname', self.host_name,
+        ]
+        run_cmd(
+            'virt-customize',
+            [
+                '-a', self.boot_disk_path,
+                *actions,
+            ]
+        )
+
+    def __configure_root_passwd(self):
+        """Configure the root password on the boot disk image for the
+        Virtual Node.
+
+        """
+        if not self.boot_disk_path or not exists(self.boot_disk_path):
+            raise ContextualError(
+                "internal error: __configure_root_passwd run before the "
+                "boot disk image was created"
+            )
+        run_cmd(
+            'virt-customize',
+            [
+                '-a', self.boot_disk_path,
+                '--root-password', 'password:%s' % self.root_passwd,
+            ]
+        )
+        # Toss the root password for the node in a root-owned readable
+        # only by owner file so we can use it later.
+        filename = "%s-passwd.txt" % self.host_name
+        with open(
+            filename, mode='w', opener=open_safe, encoding='UTF-8'
+        ) as pw_file:
+            pw_file.write("%s\n" % self.root_passwd)
+
+    def build_boot_disk(self):
+        boot_image_name = self.__make_boot_disk()
+        self.__configure_root_passwd()
+        self.__reconfigure_ssh()
+        self.__configure_netplan()
+        return boot_image_name
+
+
+class RedHatISODisk(DiskBuilder):
+    """Implementation of a disk builder for building RedHat root file
+    systems using ISO images. This will construct an image for
+    installation that has a Kickstart file in it and installs whatever
+    RedHat flavor the ISO image provides.
+
+    """
+    def __init__(self, config, node_class, node_instance, root_passwd):
+        """Constructor
+
+        """
+        self.__doc__ = DiskBuilder.__doc__
+        DiskBuilder.__init__(
+            self, config, node_class, node_instance, root_passwd
+        )
+        self.boot_iso_path = path_join(self.host_dir, "install_disk.iso")
+
+    def __populate_install_media(self, mount_point, install_root):
+        """Populate the directory under 'install_root' with the
+        generated files needed to carry out the OS install on the
+        Virtual Node.
+
+        """
+        run_cmd('cp', ['-a', path_join(mount_point, '.'), install_root])
+        iso_install_files_dir = path_join(install_root, 'install_files')
+        makedirs(iso_install_files_dir)
+        run_cmd(
+            'cp',
+            ['-v', '-a', path_join('/', 'root', '.ssh'), iso_install_files_dir]
+        )
+        kickstart = KickstartConfig(
+            self.config, self.node_class, self.node_instance,
+            self.root_passwd
+        )
+        kickstart.compose(path_join(iso_install_files_dir, 'ks.cfg'))
+        # pylint: disable=fixme
+        #
+        # XXX - Add metadata or something for the ISO class that
+        #       allows the configuration to specify the 'boot
+        #       binary path' (-b option value) and the 'boot
+        #       catalogue path' (-c option value). For now these
+        #       are hard-coded. These are paths within the ISO
+        #       image relative to the mount point of the image.
+        run_cmd(
+            'mkisofs',
+            [
+                '-b', 'isolinux/isolinux.bin',
+                '-c', 'isolinux/boot.cat',
+                '-R', '-J', '-pad',
+                '-no-emul-boot',
+                '-boot-load-size', '4',
+                '-V', "%s Kickstart Disk" % self.host_name,
+                '-o', self.boot_iso_path,
+                install_root
+            ]
+        )
+
+    def build_boot_disk(self):
+        # The source image will be an ISO that we need to retrieve,
+        # unpack, modify (add a kickstart file and ssh public key for
+        # root to use), then make into a new ISO.
+        image_url = self.disk_config.get('source_image', None)
+        source_image_name = path_join(
+            self.nodeclass_dir, 'boot-img-source.iso'
+        )
+        self._retrieve_image(image_url, source_image_name)
+        # pylint: disable=fixme
+        #
+        # Mount the ISO and copy it into a temporary directory
+        # tree. Ideally the mount would be context managed. For now we
+        # can live without that using finally.
+        #
+        # XXX - make the mount context managed
+        install_root = None
+        mount_point = None
+        try:
+            mount_point = mkdtemp(dir="/mnt")
+            install_root = mkdtemp(dir="/tmp")
+            run_cmd(
+                'mount',
+                [
+                    '-o', 'loop,ro', '-t', 'iso9660',
+                    source_image_name, mount_point
+                ]
+            )
+            self.__populate_install_media(mount_point, install_root)
+        except Exception as err:
+            raise ContextualError(
+                "failed to construct new ISO image '%s' from '%s' - %s'" % (
+                    self.boot_disk_path, source_image_name, str(err)
+                )
+            ) from err
+        finally:
+            if mount_point:
+                run_cmd('umount', [mount_point], check=False)
+                rmdir(mount_point)
+            if install_root:
+                rmtree(install_root)
+        target_dev = self.disk_config.get('target_device', None)
+        return {
+            'file_path': self.boot_disk_path,
+            'iso_path': self.boot_iso_path,
+            'target_device': target_dev,
+        }
+
+
+def pick_disk_builder(config, node_class, node_instance, root_passwd):
+    """Based on the supplied node_class configuration pick the right
+    DiskBuilder object type, instantiate it and return the instance
+    allowing the caller to get a DiskBuilder without knowing the
+    details of how the selection is made.
+
+    """
+    disk_builders = {
+        ("Debian", "qcow2"): DebianQCOWDisk,
+        ("RedHat", "iso"): RedHatISODisk,
+    }
+    # Figure out what disk builder to use and get one...
+    distro_family = node_class.get('distro', {}).get('family', "Debian")
+    boot_disk_medium = (
+        node_class
+        .get('virtual_machine', {})
+        .get('boot_disk', {})
+        .get('media_type', 'qcow2')
+    )
+    key = (distro_family, boot_disk_medium)
+    if key not in disk_builders:
+        raise ContextualError(
+            "the combination of a '%s' Linux distro family and a '%s' "
+            "root image medium is unsupported at this time - make sure "
+            "your configuration identifies both the Virtual Node distro "
+            "family and boot image medium and that they fit within these "
+            "supported combinations: %s" % (
+                key[0], key[1], str(disk_builders.keys())
+            )
+        )
+    # Create and return the disk builder
+    return disk_builders[key](config, node_class, node_instance, root_passwd)

--- a/vtds_cluster_kvm/private/scripts/kickstart.py
+++ b/vtds_cluster_kvm/private/scripts/kickstart.py
@@ -1,0 +1,740 @@
+#! python
+#
+# MIT License
+#
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# pylint: disable='consider-using-f-string'
+"""Library file containing the definition of a class used to generate
+a kickstart config for virtual nodes based on a cluster configuration.
+
+"""
+from ipaddress import IPv4Network
+from cluster_common import (
+    ContextualError,
+    find_addr_info,
+    find_address_family,
+    network_bridge_name,
+    find_mtu,
+    node_connected_networks
+)
+
+
+class KickstartConfig:
+    """Class to construct and generate a kickstart configuration file
+    based on settings found in a cluster configuration.
+
+    """
+    def __init__(self, config, node_class, node_instance, password):
+        """Constructor
+
+        """
+        self.config = config
+        self.node_class = node_class
+        self.node_instance = node_instance
+        self.class_name = node_class['class_name']
+        self.networks = node_connected_networks(node_class, config['networks'])
+        # The configuration has been filled out with all of the
+        # computed and specified node names and host names before we
+        # get here, so just use them.
+        self.node_name = (
+            node_class['node_naming']['node_names'][node_instance]
+        )
+        self.host_name = (
+            node_class['host_naming']['hostnames'][node_instance]
+        )
+        self.password = password
+
+    def __install_mode(self):
+        """Return a string containing the installation mode (for now
+        this is always 'text')
+        """
+        return "text"
+
+    def __repos(self):
+        """Return an array of 'repo' command strings indicating the
+        repositories to be used in the install.
+
+        """
+        # For now, there is only this one repo string...
+        #
+        # In the future, generate repo strings for any repos specified
+        # in the config.
+        return ['repo --name="minimal" --baseurl=file:///run/install/sources/mount-0000-cdrom/minimal']
+
+    def __packages(self):
+        """Return an array of package designators to be installed by
+        kickstart.
+
+        """
+        # For now, the following packages are hard coded and there is
+        # no way to specify them. When there is, this is the base set,
+        # others can be added to the end.
+        return [
+            "@^custom-environment",
+            "@headless-management",
+            "@legacy-unix",
+            "@network-server",
+            "@standard",
+            "@system-tools",
+            "kexec-tools",
+        ]
+
+    def __language(self):
+        """Return the language statement to be used in the kickstart
+        config.
+
+        """
+        # For now, the language will be hard coded, but, when it gets
+        # added to the configuration use it here.
+        language = "en_US.UTF-8"
+        return "lang %s" % language
+
+    # pylint: disable=fixme
+    #
+    # XXX - From here to __network() is all here to generate the
+    #       'network' command for a given network. While I like the
+    #       way this is being done, it really needs to be refactored
+    #       out into its own class. All of the commands that we use
+    #       should be, and they should all use the same approach.
+    # pylint: disable=unused-argument
+    def __net_activate(self, interface, network):
+        """Network command option generator for --activate
+
+        """
+        # Not conditional at this time, the network will be
+        # activated if it exists.
+        return ""
+
+    # pylint: disable=unused-argument
+    def __net_no_activate(self, interface, network):
+        """Network command option generator for --no-activate
+
+        """
+        # Not conditional at this time, the network will be
+        # activated if it exists.
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_bootproto(self, interface, network):
+        """Network command option generator for --bootproto
+
+        """
+        addr_info = find_addr_info(interface, "AF_INET")
+        # DHCP is used if it is configured that way or for any node
+        # instances that do not have IP addresses configured for them.
+        addresses = addr_info.get('addresses', [])
+        base_mode = (
+            'static' if addr_info.get('mode', 'dynamic') == 'static'
+            else 'dhcp'
+        )
+        return (
+            ("=%s" % base_mode) if self.node_instance < len(addresses)
+            else '=dhcp'
+        )
+
+    # pylint: disable=unused-argument
+    def __net_device(self, interface, network):
+        """Network command option generator for --device
+
+        """
+        # We are going to use the --device=<MAC> syntax here so that
+        # we don't need to know or guess the device name in the VM.
+        # This will then line up with the MAC address configured for
+        # the interface when we create the VM.
+        addr_info = find_addr_info(interface, "AF_PACKET")
+        addresses = addr_info.get('addresses', [])
+        return "=%s" % addresses[self.node_instance]
+
+    # pylint: disable=unused-argument
+    def __net_ipv4_dns_search(self, interface, network):
+        """Network command option generator for --ipv4-dns-search
+
+        """
+        # Not supported as yet.
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_ipv6_dns_search(self, interface, network):
+        """Network command option generator for --ipv6-dns-search
+
+        """
+        # No ipv6 implemented at this time. When it is, we will put
+        # the DNS info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_ipv4_ignore_auto_dns(self, interface, network):
+        """Network command option generator for --ipv4-ignore-auto-dns
+
+        """
+        # Not supported as yet.
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_ipv6_ignore_auto_dns(self, interface, network):
+        """Network command option generator for --ipv6-ignore-auto-dns
+
+        """
+        # Not supported as yet.
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_ip(self, interface, network):
+        """Network command option generator for --ip
+
+        """
+        addr_info = find_addr_info(interface, "AF_INET")
+        # DHCP is used if it is configured that way or for any node
+        # instances that do not have IP addresses configured for
+        # them. Don't assign an IP to a DHCP configured node.
+        addresses = addr_info.get('addresses', [])
+        return (
+            ("=%s" % addresses[self.node_instance])
+            if self.node_instance < len(addresses)
+            else None
+        )
+
+    def __net_netmask(self, interface, network):
+        """Network command option generator for --netmask
+
+        """
+        address_family = find_address_family(network, "AF_INET")
+        addr_info = find_addr_info(interface, "AF_INET")
+        addresses = addr_info.get('addresses', [])
+        # DHCP is used if it is configured that way or for any node
+        # instances that do not have IP addresses configured for
+        # them. Don't assign an IP to a DHCP configured node.
+        return (
+            (
+                "=%s" % str(
+                    IPv4Network(address_family['cidr'], strict=False).netmask
+                )
+            )
+            if self.node_instance < len(addresses)
+            else None
+        )
+
+    # pylint: disable=unused-argument
+    def __net_ipv6(self, interface, network):
+        """Network command option generator for --ipv6
+
+        """
+        # No ipv6 implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_gateway(self, interface, network):
+        """Network command option generator for --gateway
+
+        """
+        address_family = find_address_family(network, "AF_INET")
+        gateway = address_family.get('gateway', None)
+        return (
+            ("=%s" % gateway) if gateway is not None else None
+        )
+
+    # pylint: disable=unused-argument
+    def __net_ipv6gateway(self, interface, network):
+        """Network command option generator for --ipv6gateway
+
+        """
+        # No ipv6 implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_nodefroute(self, interface, network):
+        """Network command option generator for --nodefroute
+
+        """
+        address_family = find_address_family(network, "AF_INET")
+        gateway = address_family.get('gateway', None)
+        # If there is no gateway configured, it gets the nodefroute
+        # setting. Not sure this is the right way to do this forwver
+        # but it should work for now.
+        return None if gateway is not None else ""
+
+    # pylint: disable=unused-argument
+    def __net_nameserver(self, interface, network):
+        """Network command option generator for --nameserver
+
+        """
+        address_family = find_address_family(network, "AF_INET")
+        nameservers = ','.join(address_family.get('nameservers', []))
+        return (
+            ("=%s" % nameservers) if nameservers else None
+        )
+
+    # pylint: disable=unused-argument
+    def __net_hostname(self, interface, network):
+        """Network command option generator for --hostname
+
+        """
+        return "=%s" % self.host_name
+
+    # pylint: disable=unused-argument
+    def __net_onboot(self, interface, network):
+        """Network command option generator for --onboot
+
+        """
+        # Not conditional at this time. Interfaces always come up on
+        # boot.
+        return "=yes"
+
+    # pylint: disable=unused-argument
+    def __net_dhcpclass(self, interface, network):
+        """Network command option generator for --dhcpclass
+
+        """
+        # Not implemented at this time. Might need for vShasta though.
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_mtu(self, interface, network):
+        """Network command option generator for --mtu
+
+        """
+        bridge_name = network_bridge_name(network)
+        return "=%s" % find_mtu(bridge_name)
+
+    # pylint: disable=unused-argument
+    def __net_noipv4(self, interface, network):
+        """Network command option generator for --noipv4
+
+        """
+        # Not conditional at this time, all interfaces have ipv4
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_noipv6(self, interface, network):
+        """Network command option generator for --noipv6
+
+        """
+        # Not conditional at this time, ipv6 is not implemented so no
+        # interfaces get ipv6
+        return ""
+
+    # pylint: disable=unused-argument
+    def __net_bondslaves(self, interface, network):
+        """Network command option generator for --bondslaves
+
+        """
+        # No bonding implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_bondopts(self, interface, network):
+        """Network command option generator for --bondopts
+
+        """
+        # No bonding implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_vlanid(self, interface, network):
+        """Network command option generator for --vlanid
+
+        """
+        # No VLANs implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_interfacename(self, interface, network):
+        """Network command option generator for --interfacename
+
+        """
+        # No interfacenames (no VLANs) implemented at this time. When
+        # it is, we will put the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_teamslaves(self, interface, network):
+        """Network command option generator for --teamslaves
+
+        """
+        # No teams implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_teamconfig(self, interface, network):
+        """Network command option generator for --teamconfig
+
+        """
+        # No teams implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_bridgeslaves(self, interface, network):
+        """Network command option generator for --bridgeslaves
+
+        """
+        # No bridging implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_bridgeopts(self, interface, network):
+        """Network command option generator for --bridgeopts
+
+        """
+        # No bridging implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    # pylint: disable=unused-argument
+    def __net_bindto(self, interface, network):
+        """Network command option generator for --bindto
+
+        """
+        return "=mac"
+
+    # pylint: disable=unused-argument
+    def __net_ethtool(self, interface, network):
+        """Network command option generator for --ethtool
+
+        """
+        # No ethtool implemented at this time. When it is, we will put
+        # the info here...
+        return None
+
+    def __net_options(self):
+        """Return a dictionary of option to bound method references
+        that can be used to construct a 'network' command. Each method
+        will return an empty string if the option is active and has no
+        value, a non-empty string (formatted as '=<value>') if the
+        option is active and has a value, and None if the option is
+        not active for the specified network name ('netname') when
+        called.
+
+        """
+        return {
+            '--activate': self.__net_activate,
+            '--no-activate': self.__net_no_activate,
+            '--bootproto': self.__net_bootproto,
+            '--device': self.__net_device,
+            '--ipv4-dns-search': self.__net_ipv4_dns_search,
+            '--ipv6-dns-search': self.__net_ipv6_dns_search,
+            '--ipv4-ignore-auto-dns': self.__net_ipv4_ignore_auto_dns,
+            '--ipv6-ignore-auto-dns': self.__net_ipv6_ignore_auto_dns,
+            '--ip': self.__net_ip,
+            '--netmask': self.__net_netmask,
+            '--ipv6': self.__net_ipv6,
+            '--gateway': self.__net_gateway,
+            '--ipv6gateway': self.__net_ipv6gateway,
+            '--nodefroute': self.__net_nodefroute,
+            '--nameserver': self.__net_nameserver,
+            '--hostname': self.__net_hostname,
+            '--ethtool': self.__net_ethtool,
+            '--onboot': self.__net_onboot,
+            '--dhcpclass': self.__net_dhcpclass,
+            '--mtu': self.__net_mtu,
+            '--noipv4': self.__net_noipv4,
+            '--noipv6': self.__net_noipv6,
+            '--bondslaves': self.__net_bondslaves,
+            '--bondoppts': self.__net_bondopts,
+            '--vlanid': self.__net_vlanid,
+            '--interfacename': self.__net_interfacename,
+            '--teamslaves': self.__net_teamslaves,
+            '--teamconfig': self.__net_teamconfig,
+            '--bridgeslaves': self.__net_bridgeslaves,
+            '--bridgeopts': self.__net_bridgeopts,
+            '--bindto': self.__net_bindto,
+        }
+
+    def __network(self, interface, network):
+        """Generate the network statement to be used to configure a
+        named network from the configuration.
+
+        """
+        options = self.__net_options()
+        args = [
+            "%s%s" % (option, func(interface, network))
+            for option, func in options.items()
+            if func(interface, network) is not None
+        ]
+        return "network %s" % ' '.join(args)
+
+    def __find_network(self, network_name):
+        """Find the named network in the set of networks supplied for
+        this node.
+
+        """
+        networks = [
+            network
+            for _, network in self.networks.items()
+            if network.get('network_name', "") == network_name
+        ]
+        if len(networks) < 1:
+            raise ContextualError(
+                "no network named '%s' in the "
+                "cluster configuration" % network_name
+            )
+        if len(networks) > 1:
+            raise ContextualError(
+                "more than one network named '%s' in the "
+                "cluster configuration" % network_name
+            )
+        return networks[0]
+
+    def __networks(self):
+        """Return the list of network statements to be used to set up
+        networks on the Virtual Node.
+
+        """
+        return [
+            self.__network(
+                interface,
+                self.__find_network(interface['cluster_network'])
+            )
+            for _, interface in self.node_class.get(
+                'network_interfaces', {}
+            ).items()
+        ]
+
+    def __install_medium(self):
+        """Return the statement indicating what installation medium to
+        use for installation.
+
+        """
+        # For now, the only installation medium we will use is an ISO
+        # mounted as a cdrom, so, 'cdrom'
+        return "cdrom"
+
+    def __firstboot(self):
+        """Return the 'firstboot' statement indicating whether
+        firstboot is to be enabled or not.
+
+        """
+        states = {
+            True: "--enable",
+            False: "--disable",
+        }
+        # For now this is not configurable.
+        firstboot = True
+        return "firstboot %s" % states[firstboot]
+
+    def __reboot(self):
+        """Construct and return a string containing the 'reboot'
+        statement controlling what to do once installation is
+        complete.
+
+        """
+        options = "--eject"
+        return "reboot %s" % options
+
+    def __xwindows(self):
+        """Return a string containing the instruction for what to do
+        about X Windows (generally we just want to skip X Windows)
+        during the install.
+
+        """
+        return "skipx"
+
+    def __ignore_disks(self):
+        """Return a string with the instruction indicating what disks
+        to ignore during install.
+
+        """
+        options = "--only-use=vda"
+        return "ignoredisk %s" % options
+
+    def __bootloader(self):
+        """Return a string with the bootloader instructions for the
+        installed system.
+
+        """
+        options = '--append="crashkernel=auto" --location=mbr --boot-drive=vda'
+        return "bootloader %s" % options
+
+    def __partitioning(self):
+        """Return a string containing the instructions for
+        partitioning disks.
+
+        """
+        # For now there is no configuration for this. Just use plain
+        # auto partitioning.
+        return "autopart --type=plain"
+
+    def __partition_clearing(self):
+        """Return the partition clearing strategy for the install
+
+        """
+        # For now this is hard-coded
+        options = "--all --initlabel --drives=vda"
+        return "clearpart %s" % options
+
+    def __timezone(self):
+        """Return the timezone setting instruction for the install
+
+        """
+        # For now this is hard-coded
+        timezone = "US/Central"
+        options = "--isUtc"
+        return "timezone %s %s" % (timezone, options)
+
+    def __root_password(self):
+        """Return the root password setting instruction
+
+        """
+        # pylint: disable=fixme
+        #
+        # For now, crypt() is deprecated in Python and I have not been
+        # able to find a viable generally applicable solution for
+        # encrypted password generation. I can make the generated
+        # kickstart file root-only readable, or delete the rootpw line
+        # altogether from it in the post script if needed.
+        #
+        # XXX - this should use an encrypted password and --iscrypted
+        options = "--plaintext"
+        return "rootpw %s %s" % (options, self.password)
+
+    def __kdump_enable(self):
+        """Return the add-on instruction to enable kdump on the
+        Virtual Node
+
+        """
+        section = [
+            "%addon com_redhat_kdump --enable --reserve-mb='auto'",
+            '%end'
+        ]
+        return '\n'.join(section)
+
+    def __password_policies(self):
+        """Return the list of password policy instructions for the
+        Virtual Node
+
+        """
+        # For now these are hard-coded
+        policies = {
+            'root': "--minlen=6 --minquality=1 --notstrict --nochanges --notempty",
+            'user': "--minlen=6 --minquality=1 --notstrict --nochanges --emptyok",
+            'luks': "--minlen=6 --minquality=1 --notstrict --nochanges --notempty",
+        }
+        return [
+            "pwpolicy %s %s" % (key, value) for key, value in policies.items()
+        ]
+
+    def __post_install(self):
+        """ Return the lines of a post-install script as an array of strings
+
+        """
+        # For now, these are hard-coded
+        return [
+            "mkdir -p /mnt/cdrom",
+            "mount -o ro /dev/cdrom /mnt/cdrom",
+            "cp -r /mnt/cdrom/install_files/.ssh /root",
+            "umount /mnt/cdrom",
+        ]
+
+    def __sect_pre(self, options=""):
+        """Compose the %pre section as a string.
+
+        """
+        # For now this is hard-coded and non-existent
+        return ""
+
+    def __sect_packages(self, options=""):
+        """Compose the packages section and return it as a string.
+
+        """
+        section = [
+            "%packages " + options,
+            *self.__packages(),
+            "%end"
+        ]
+        return '\n'.join(section)
+
+    def __sect_anaconda(self, options=""):
+        """Compose the %anaconda section and return it as a string.
+
+        """
+        section = [
+            "%anaconda " + options,
+            *self.__password_policies(),
+            "%end"
+        ]
+        return '\n'.join(section)
+
+    def __sect_post(self, options=""):
+        """Compose the %post section and return it as a string.
+
+        """
+        section = [
+            "%post " + options,
+            *self.__post_install(),
+            "%end"
+        ]
+        return '\n'.join(section)
+
+    def __sect_onerr(self, options=""):
+        """Compose the %onerr section and retiurn it as a string
+
+        """
+        # For now this is hard-coded and non-existent
+        return ""
+
+    def __sect_command(self):
+        """Compose the command section of the kickstart file and
+        return it as a string. This is basically the whole kickstart
+        file, since it includes all the other sections.
+
+        """
+        return '\n\n'.join(
+            [
+                self.__sect_pre(),
+                self.__install_mode(),
+                *self.__repos(),
+                self.__sect_packages(),
+                self.__language(),
+                *self.__networks(),
+                self.__install_medium(),
+                self.__firstboot(),
+                self.__reboot(),
+                self.__xwindows(),
+                self.__ignore_disks(),
+                self.__bootloader(),
+                self.__partitioning(),
+                self.__partition_clearing(),
+                self.__timezone(),
+                self.__root_password(),
+                self.__kdump_enable(),
+                self.__sect_anaconda(),
+                self.__sect_post(),
+                self.__sect_onerr(),
+                "",
+            ]
+        )
+
+    def compose(self, path):
+        """Compose the overall Kickstart file and write it out as a
+        file at 'path'
+
+        """
+        with open(path, 'w', encoding='UTF-8') as ks_file:
+            # For now, make the Kickstart file be an RHEL8 Kickstart file...
+            ks_file.write("\n".join(["#version=RHEL9", self.__sect_command()]))

--- a/vtds_cluster_kvm/private/scripts/node_builder.py
+++ b/vtds_cluster_kvm/private/scripts/node_builder.py
@@ -1,0 +1,370 @@
+#! python
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# pylint: disable='consider-using-f-string'
+"""Base class for Node Builder classes. Node Builders implement a
+particular method of building a Virtual Node on a Virtual Blade.
+
+"""
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+from tempfile import (
+    NamedTemporaryFile
+)
+from uuid import uuid4
+
+from jinja2 import (
+    Template,
+    TemplateError
+)
+
+from cluster_common import (
+    ContextualError,
+    compute_node_name,
+    compute_hostname,
+    run_cmd,
+    node_mac_addrs,
+    find_addr_info,
+    find_address_family,
+    network_length,
+    network_bridge_name,
+    find_mtu,
+    node_connected_networks
+)
+
+from disk_builder import pick_disk_builder
+
+
+# We want a bunch of information harvested for easy use by inheritors,
+# shut lint up about our large number of instance attributes
+#
+# pylint: disable=too-many-instance-attributes
+class NodeBuilder(metaclass=ABCMeta):
+    """Base class for a node-builder class. These classes are used for
+    different mechanisms for building Virtual Nodes on a Virtual
+    Blade.
+
+    """
+    def __init__(self, config, node_class, node_instance, root_passwd):
+        """Constructor
+
+        """
+        self.config = config
+        self.node_class = node_class
+        self.node_instance = node_instance
+        self.root_passwd = root_passwd
+        self.class_name = node_class['class_name']
+        self.networks = node_connected_networks(node_class, config['networks'])
+        self.node_name = compute_node_name(node_class, node_instance)
+        self.host_name = compute_hostname(node_class, node_instance)
+        self.virtual_machine = node_class.get('virtual_machine', {})
+        self.disk_builder = pick_disk_builder(
+            config, node_class, node_instance, root_passwd
+        )
+
+        # Get the CPU and Memory parameters...
+        try:
+            self.memsize = str(
+                int(self.virtual_machine['memory_size_mib']) * 1024
+            )
+        except KeyError as err:
+            raise ContextualError(
+                "configuration error: no 'memory_size_mib' found in "
+                "Virtual Machine configuration for Virtual Node class '%s': "
+                " %s " % (self.class_name, str(self.node_class))
+            ) from err
+        except ValueError as err:
+            raise ContextualError(
+                "configuration error: the value of 'memory_size_mib' ('%s') "
+                "must be an integer value in Virtual Machine configuration "
+                "for Virtual Node class '%s': %s " % (
+                    self.virtual_machine['memory_size_mib'],
+                    self.class_name,
+                    str(self.node_class)
+                )
+            ) from err
+        try:
+            self.cpus = self.virtual_machine['cpu_count']
+        except KeyError as err:
+            raise ContextualError(
+                "configuration error: no 'cpu_count' found in "
+                "Virtual Machine configuration for Virtual Node "
+                "class '%s': %s " % (self.class_name, str(self.node_class))
+            ) from err
+
+    @abstractmethod
+    def build(self):
+        """Build the Virtual Node
+
+        """
+
+
+class DebianQCOWNode(NodeBuilder):
+    """NodeBuilder Class for building Virtual Nodes using an XML
+    description of the virtual machine and the 'virsh create'
+    command. This also assumes we are creating a boot disk image from
+    a qcow2 image and directly customizing it using virt-customize.
+
+    """
+    def __init__(self, config, node_class, node_instance, root_passwd):
+        """Constructor
+
+        """
+        self.__doc__ = NodeBuilder.__doc__
+        NodeBuilder.__init__(
+            self, config, node_class, node_instance, root_passwd
+        )
+
+    def __make_net_if(self, interface, network):
+        """Given an interface configuration ('interface') taken from a
+        node class and the matching network configuration ('network')
+        taken from self.networks, return a context for rendering XML
+        and for composing a netplan configuration for a single
+        interface in this Virtual Node.
+
+        """
+        node_instance = int(self.node_instance)
+        netname = interface['cluster_network']
+        bridge_name = network_bridge_name(network)
+        mtu = find_mtu(bridge_name)
+        ipv4_info = find_addr_info(interface, "AF_INET")
+        mac_addrs = node_mac_addrs(interface)
+        addresses = ipv4_info.get('addresses', [])
+        address_family = find_address_family(network, "AF_INET")
+        net_length = network_length(address_family, netname)
+        try:
+            mode = ipv4_info['mode']
+        except KeyError as err:
+            raise ContextualError(
+                "configuration error: AF_INET addr_info in interface "
+                "for network '%s' in node class has no 'mode' value: %s" % (
+                    netname, str(self.node_class)
+                )
+            ) from err
+        dhcp4 = (
+            mode in ['dynamic', 'reserved'] or
+            node_instance >= len(addresses)
+        )
+        ipv4_addr = (
+            addresses[self.node_instance]
+            if node_instance < len(addresses)
+            else None
+        )
+        ipv4_netlen = (
+            net_length
+            if node_instance < len(addresses)
+            else None
+        )
+        return {
+            'ifname': netname,
+            'dhcp4': dhcp4,
+            'ipv4_addr': ipv4_addr,
+            'ipv4_netlength': ipv4_netlen,
+            'name_servers': [
+                "",
+                ...
+            ],
+            'netname': netname,
+            'source_if': bridge_name,
+            'mac_addr': mac_addrs[node_instance],
+            'mtu': mtu,
+        }
+
+    def __make_net_ifs(self):
+        """Configure the network interfaces on the boot disk image and
+        return the template description of the network interfaces.
+
+        """
+        context = [
+            self.__make_net_if(
+                interface, self.networks[interface['cluster_network']]
+            )
+            for _, interface in self.node_class.get(
+                'network_interfaces', {}
+            ).items()
+        ]
+        return context
+
+    def __compose(self):
+        """Compose the template data that will be used to fill out the
+        XML template that will be used to create the Virtual Node
+        using 'virsh create <filename>'
+
+        """
+        return {
+            'hostname': self.node_name,
+            'uuid': str(uuid4()),
+            'memsize_kib': self.memsize,
+            'cpus': self.cpus,
+            'boot_disk': self.disk_builder.build_boot_disk(),
+            'extra_disks': self.disk_builder.build_extra_disks(),
+            'interfaces': self.__make_net_ifs(),
+        }
+
+    def __create(self):
+        """Compose an XML definition of the Virtual Node and create
+        it on the current blade.
+
+        """
+        context = self.__compose()
+        try:
+            vm_template = self.node_class['vm_xml_template']
+        except KeyError as err:
+            raise ContextualError(
+                "internal configuration error: Virtual Node class '%s' does "
+                "not have a VM XML template stored in it. This may be some "
+                "kind of module version mismatch."
+            ) from err
+        template = Template(vm_template)
+        try:
+            vm_xml = template.render(**context)
+        except TemplateError as err:
+            raise ContextualError(
+                "internal error: error rendering VM XML file from context and "
+                "XML template - %s" % str(err)
+            ) from err
+        with NamedTemporaryFile(mode='w', encoding='UTF-8') as tmpfile:
+            tmpfile.write(vm_xml)
+            tmpfile.flush()
+            run_cmd('virsh', ['define', tmpfile.name])
+            run_cmd('virsh', ['start', self.node_name])
+
+    def build(self):
+        self.__create()
+
+
+class RedHatISONode(NodeBuilder):
+    """Node builder class for building RedHat style nodes using ISO
+    installation media.
+
+    """
+
+    def __init__(self, config, node_class, node_instance, root_passwd):
+        """Constructor
+
+        """
+        self.__doc__ = NodeBuilder.__doc__
+        NodeBuilder.__init__(
+            self, config, node_class, node_instance, root_passwd
+        )
+
+    def __make_net_opt(self, interface):
+        """Using a network configuration for the Virtual Node, compose
+        the '--network' option to use in the virt-install command for
+        that network.
+
+        """
+        network_name = 'network=' + interface['cluster_network']
+        mac_addrs = node_mac_addrs(interface)
+        mac = (
+            ',mac=' + mac_addrs[self.node_instance]
+            if self.node_instance < len(mac_addrs)
+            else ""
+        )
+        return "--network=" + network_name + mac
+
+    def __make_virt_install_args(self, boot_disk_info, extra_disks):
+        """Compose the arguments to pass to the virt-install command
+        to install the Virtual Node.
+
+        """
+        # Get the boot disk size in GB from the disk size in MB,
+        # defaulting to 100GB
+        boot_size = str(int(
+            self.virtual_machine
+            .get('boot_disk', {})
+            .get('disk_size_mb', '100000')
+        ) / 1000)
+        base_opts = [
+            '--name', self.node_name,
+            '--wait=-1',
+            '--location', boot_disk_info['iso_path'],
+            '--disk', 'path=%s,size=%s' % (
+                boot_disk_info['file_path'], boot_size
+            ),
+            '--os-variant', 'rocky8',
+            '--ram', str(self.virtual_machine.get('memory_size_mib', '4096')),
+            '--vcpus', str(self.virtual_machine.get('cpu_count', '1')),
+            '--graphics', 'none',
+            '--console', 'pty,target_type=virtio',
+            '--noautoconsole',
+            '--extra-args', 'inst.ks=cdrom:/install_files/ks.cfg'
+        ]
+        extra_disk_opts = [
+            '--disk=path=%s' % disk_info['file_path']
+            for disk_info in extra_disks
+        ]
+        net_opts = [
+            self.__make_net_opt(interface)
+            for _, interface in self.node_class.get(
+                'network_interfaces', {}
+            ).items()
+        ]
+        return (
+            base_opts +
+            extra_disk_opts +
+            net_opts
+        )
+
+    def build(self):
+        boot_disk_info = self.disk_builder.build_boot_disk()
+        extra_disks = self.disk_builder.build_extra_disks()
+        inst_args = self.__make_virt_install_args(boot_disk_info, extra_disks)
+        run_cmd('virt-install', inst_args)
+
+
+def pick_node_builder(config, node_class, node_instance, root_passwd):
+    """Based on the supplied node_class configuration pick the right
+    NodeBuilder object type, instantiate it and return the instance
+    allowing the caller to get a NodeBuilder without knowing the
+    details of how the selection is made.
+
+    """
+    node_builders = {
+        ("Debian", "qcow2"): DebianQCOWNode,
+        ("RedHat", "iso"): RedHatISONode,
+    }
+    # Figure out what node builder to use and get one...
+    distro_family = node_class.get('distro', {}).get('family', "Debian")
+    boot_disk_medium = (
+        node_class
+        .get('virtual_machine', {})
+        .get('boot_disk', {})
+        .get('media_type', 'qcow2')
+    )
+    key = (distro_family, boot_disk_medium)
+    if key not in node_builders:
+        raise ContextualError(
+            "the combination of a '%s' Linux distro family and a '%s' "
+            "root image medium is unsupported at this time - make sure "
+            "your configuration identifies both the Virtual Node distro "
+            "family and boot image medium and that they fit within these "
+            "supported combinations: %s" % (
+                key[0], key[1], str(node_builders.keys())
+            )
+        )
+    # Create and return the node builder
+    return node_builders[key](config, node_class, node_instance, root_passwd)


### PR DESCRIPTION
## Summary and Scope

Refactor the code in the blade level Cluster deployments scripts to handle creation of Virtual Nodes and Virtual Networks for both Debian family (Ubuntu) and RedHat family (Rocky Linux) distributions. This refactor defines a generic Node Builder class and Disk Builder class and implements two flavors of those classes. One flavor knows how to customize a QCOW2 Debian family live image and use it to bring up a Virtual Node running Ubuntu (or whatever QCOW live image Debian family linux is used) using an XML definition of the node constructed from the cluster configuration. The other knows how to build an installation ISO with a Kickstart configuration constructed from the cluster configuration and kick off a `virt_install` command constructed from the cluster configuration to create the Virtual Node.

Other work in the refactor included pulling code common to the deploy script, node builders and disk builders out into a common library, defining a base configuration for a Rocky Linux Virtual Node, eliminating a multiple source of truth issue in the cluster configuration and other minor fixes.

There is a lot here. I have added commentary in the PR to aid in reviewing the code.

## Issues and Related PRs

* Resolves [VSHA-648](https://jira-pro.it.hpe.com:8443/browse/VSHA-648)

## Testing

This was tested by building two vTDS systems. The first is a Rocky Linux system that will become the foundation for the OpenCHAMI vTDS configuration. The second is the Ubuntu system that was used for the FSM network connectivity demo in 2024. Both systems built successfully.