### PR TITLE
Fix Fencepost error and Possible Manual Config Conflict in MAC Address Generation

### DIFF
--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -878,7 +878,7 @@ class Addressing(AddressingBase):
             family['family']: [
                 family['addresses'].pop(0)
                 if instance in self.connected_instances else None
-                for instance in range(0, top_instance)
+                for instance in range(0, top_instance + 1)
             ]
             for family in address_families
             if 'family' in family and 'addresses' in family

--- a/vtds_cluster_kvm/private/cluster.py
+++ b/vtds_cluster_kvm/private/cluster.py
@@ -413,7 +413,8 @@ class Cluster(ClusterAPI):
         node_count = int(node_class.get('node_count', 0))
         interfaces = node_class.get('network_interfaces', {})
         for key, interface in interfaces.items():
-            layer_2 = interface.get(
+            addr_info = interface.get('addr_info', {})
+            layer_2 = addr_info.get(
                 "layer_2",
                 {
                     'family': 'AF_PACKET',
@@ -426,11 +427,11 @@ class Cluster(ClusterAPI):
                 self.__random_mac(prefix)
                 for i in range(0, node_count - existing_count)
             ]
-            interface['addr_info'] = (
-                interface['addr_info'] if 'addr_info' in interface else
-                {}
-            )
-            interface['addr_info']['layer_2'] = layer_2
+            addr_info['layer_2'] = layer_2
+            interface['addr_info'] = addr_info
+            # While there is no reason to believe that adjusting 'interface'
+            # made it into a new object, it doesn't hurt to be explicit here
+            # and put the modified 'interface' back into interfaces.
             interfaces[key] = interface
 
     def __add_xml_template(self, node_class):


### PR DESCRIPTION
## Summary and Scope

When trying to obtain MAC addresses from AF_PACKET address family network information from an Addressing object obtained from vtds-cluster-kvm, in the OpenCHAMI Application layer, I was getting no MAC addresses even though there was one defined. While investigating this, I found two issues. The first was that there is a fencepost error copying the addresses into the Addressing object constructor. That is why I was getting no MAC addresses. The second was that by unconditionally and explicitly generating an address information block called 'layer_2' in node class definitions while generating MAC addresses the code potentially creates a case where there are two conflicting AF_PACKET address information blocks (one manually configured, one generated). The code here needs to be changed to use the manually configured AF_PACKET address information block if one is present and only create the 'layer_2' block if none is present.

This PR fixes both of those issues.

## Issues and Related PRs

* Resolves [VSHA-666](https://jira-pro.it.hpe.com:8443/browse/VSHA-666)

## Testing

Tested by deploying vTDS OpenCHAMI platform and verifying that MAC addresses were being generated correctly and propagated correctly.
