### PR TITLE
Add logic to put host blade net Virtual Nodes in blade /etc/hosts

### DIFF
--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -39,7 +39,7 @@ cluster:
     # This is not a cluster network (i.e. it should not be used by
     # applications running on the cluster for anything). It is here to
     # aid in setting up the cluster during deployment.
-    non_cluster: True
+    non_cluster: true
     # Do not set 'delete' to true here or in an overlay. This network
     # must be defined or the Cluster layer APIs that support
     # deployment at the Application layer will not all work correctly.


### PR DESCRIPTION
## Summary and Scope

When trying to reach a Virtual Node on a vTDS cluster, one way to do it is to log into the Virtual Blade on which the node resides and then log into the node from there using the local network on the blade. Until this PR this required the user to know the IP address of the Virtual Node on the blade. With this PR, there will be an /etc/hosts entry added when a Virtual Node is created to allow hostname access to the Virtual Node from its hosting Virtual Blade.

## Issues and Related PRs

* Resolves [VSHA-626](https://jira-pro.it.hpe.com:8443/browse/VSHA-626)

## Testing

Tested using an OpenChami on vTDS deployment. Verified that /etc/hosts is updated and that the change is idempotent.