### PR TITLE
Thread Virtual Node creation to accelerate multi-node deployment

### DIFF
--- a/vtds_cluster_kvm/private/scripts/deploy_cluster_to_blade.py
+++ b/vtds_cluster_kvm/private/scripts/deploy_cluster_to_blade.py
@@ -44,6 +44,7 @@ from subprocess import (
 from tempfile import (
     NamedTemporaryFile
 )
+from threading import Thread
 from uuid import uuid4
 from time import sleep
 import json
@@ -842,9 +843,20 @@ def main(argv):
     # currently deployed.
     for node in nodes:
         node.remove()
-    # Now create all the Virtual Nodes in the list
-    for node in nodes:
-        node.create()
+    # Now create all the Virtual Nodes in the list. Do this in threads
+    # to allow the creations to run in parallel.
+    threads = [
+        Thread(target=node.create, args=())
+        for node in nodes
+    ]
+    # Start the threads
+    for thread in threads:
+        thread.start()
+
+    # Wait for the threads to complete
+    for thread in threads:
+        thread.join()
+
     # Now wait for the Virtual Nodes to be up and running (listening
     # on the SSH port)
     for node in nodes:


### PR DESCRIPTION
## Summary and Scope

Deploying Virtual Nodes on a single Virtual Blade was done linearly, so it took linear time on the order of 8 to 10 minutes per Virtual Node. This increased the time required to deploy a 4 compute node OpenCHAMI system to a bit over an hour from 25 minutes to deploy an OpenCHAMI system with only a Management node, and was unacceptably long. As part of implementing Compute Nodes and their networks, therefore, it was necessary to parallelize the Virtual Node creation process on each blade (cluster deployments across blades are already parallel by blade). This PR makes that enhancement.

## Issues and Related PRs

* Part of [VSHA-669](https://jira-pro.it.hpe.com:8443/browse/VSHA-669)

## Testing

Tested by creating both 4 compute node plus one management node OpenCHAMI clusters on single Virtual Blades and 0 compute node plus one management node OpenCHAMI clusters. The time to build with 4 compute nodes increases from about 25 minutes to about 30 minutes with this change in place.