### PR TITLE
Change some copies to deepcopies to fix latent corruption bugs

### DIFF
--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -24,6 +24,7 @@
 and operations in the provider layer.
 
 """
+from copy import deepcopy
 from subprocess import (
     Popen,
     TimeoutExpired
@@ -863,15 +864,15 @@ class Addressing(AddressingBase):
     def __init__(self, connected_instances, address_families):
         """Constructor
         """
-        self.connected_instances = connected_instances.copy()
+        self.connected_instances = deepcopy(connected_instances)
         # Our local address_families contains, for each address
         # family, an expanded list of addresses indexed by instance
         # number. The incoming address_families contains a compressed
         # list of addresses that lines up with the list of instances
         # in the object. Expand the list here, filling in None for any
         # instance numbers that are not in the list of instances.
-        tmp = self.connected_instances.copy()
-        address_families = address_families.copy()  # So we can muck with it...
+        tmp = deepcopy(self.connected_instances)
+        address_families = deepcopy(address_families)  # So we can mess with it
         tmp.sort()  # So the highest numbered instance is in [-1]
         top_instance = tmp[-1]
         self.families = {
@@ -901,4 +902,4 @@ class Addressing(AddressingBase):
         ]
 
     def instances(self):
-        return self.connected_instances.copy()
+        return deepcopy(self.connected_instances)


### PR DESCRIPTION
## Summary and Scope

While getting VSHA-670 to work I discovered a bug in vtds-cluster-kvm where layer configuration data were being corrupted by the library by being manipulated without being deep-copied. This PR fixes that bug.

## Issues and Related PRs

* Relates to VSHA-670

## Testing

Tested by building an OpenCHAMI system on vTDS and deploying sushi-emulator on it. Verified that the corruption was no longer causing a failure.