### PR TITLE
Rework addressing API for connected blades which was not working

### DIFF
--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -158,8 +158,8 @@ cluster:
               # Each connected blade instance is assigned an IP
               # address on the Virtual Network using the following
               # list of blade IPs matched one-to-one with blade
-              # instances. If either list runs out early, no IP
-              # address is assigned to remaining blade instances..
+              # instances. If this list runs out early, no IP
+              # address is assigned to remaining blade instances.
               addresses:
                 - 10.254.0.1
               # If this blade class provides a DHCP server on this


### PR DESCRIPTION
## Summary and Scope

This PR reworks the addressing API for Virtual Blades connected to Virtual Networks which was, previously, not working. The addressing API returns publicly accessible addressing information related to Virtual Blades and Virtual Nodes based on configuration or other data that is private to the Cluster layer. The Virtual Node addressing data was being prepared correctly, but the Virtual Blade addressing data was not. This prevented the OpenCHAMI Application layer from making appropriate associations between Virtual Blades and their configured XNAMEs. By reworking the mechanism for Virtual Blades this PR fixes that problem.

## Issues and Related PRs

* Partly Resolves [VSHA-679](https://jira-pro.it.hpe.com:8443/browse/VSHA-679)

## Testing

Tested on OpenCHAMI on vTDS systems. Verified that I can get a proper BMC XNAME to Virtual Blade mapping and generate a BMC ID Map file from there. That was used with Magellan to produce correct SMD content on OpenCHAMI to support Virtual Compute Nodes alongside RIE simulated node data.