### PR TITLE
Fix latent out of range error in Addressing API objects

### DIFF
--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -914,10 +914,18 @@ class Addressing(AddressingBase):
         address_families = deepcopy(address_families)  # So we can mess with it
         tmp.sort()  # So the highest numbered instance is in [-1]
         top_instance = tmp[-1]
+        # For each address family provided, fill out the addresses
+        # list with the address corresponding to the instance of the
+        # instance is connected and there is an address for that
+        # instance in that address family. Otherwise fill in None for
+        # that instance. This gives us a dictionary of family to
+        # address list mappings that has the same number of elements
+        # (some filled with None) for each family.
         self.families = {
             family['family']: [
                 family['addresses'].pop(0)
-                if instance in self.connected_instances else None
+                if instance in self.connected_instances and family['addresses']
+                else None
                 for instance in range(0, top_instance + 1)
             ]
             for family in address_families


### PR DESCRIPTION
## Summary and Scope

The Addressing object in the Cluster API can contain several different address families with different addressing and connectivity in each family. The code was expecting all connectivity to be the same for each family, which had the potential to result in an out of range array reference (actually, a pop from a zero length array) if a family prematurely exhausted its address list. This PR prevents that by ensuring that address list exhaustion results in populating remaining addresses with None, which is expected behavior for the API object.

This is a backward compatible bugfix.

## Issues and Related PRs

* Resolves [VSHA-681](https://jira-pro.it.hpe.com:8443/browse/VSHA-681)

## Testing

Deployed a vTDS OpenCHAMI system, verified that it performed discovery correctly (which uses this aspect of Addressing) and then removed it.