### PR TITLE
Add blade_interconnect() method to VirtualNetworks API object

### DIFF
--- a/vtds_cluster_kvm/private/api_objects.py
+++ b/vtds_cluster_kvm/private/api_objects.py
@@ -238,6 +238,10 @@ class VirtualNetworks(VirtualNetworksBase):
         network = self.__network_by_name(network_name)
         return network.get('non_cluster', False)
 
+    def blade_interconnect(self, network_name):
+        network = self.__network_by_name(network_name)
+        return network.get('blade_interconnect', None)
+
     @staticmethod
     def __is_connected_to_blades(address_family, blade_class):
         """Look through the connected blades in the supplied network


### PR DESCRIPTION
## Summary and Scope

This PR adds a blade_interconnect() method to the VirtualNetworks API object to allow layers above the Cluster layer to learn the name of the underlying Blade Interconnect supporting a given virtual network.

## Issues and Related PRs

* Partly Resolves [VSHA-701](https://jira-pro.it.hpe.com:8443/browse/VSHA-701)
* Merge after [vtds-base PR 55](https://github.com/Cray-HPE/vtds-base/pull/55)

## Testing

### Tested on:

vTDS

### Test description:

Tested by deploying OpenCHAMI on vTDS to verify that the base library changes and this change are compatible.
