### PR TITLE
Fix Rocky / Kickstart boot issues and configurability

### DIFF
--- a/vtds_cluster_kvm/private/config/config.yaml
+++ b/vtds_cluster_kvm/private/config/config.yaml
@@ -327,6 +327,14 @@ cluster:
           # will be booted to get the qcow, then customized using
           # virt-customize.
           media_type: qcow2
+          # The 'installer' block specifies the kind of installer to be
+          # used ('virt-customize', 'kickstart', "none") and then
+          # installer specific configuration to be used in setting up
+          # for that installer. There is not currently any configuration
+          # for 'virt-customize'.
+          installer:
+            style: virt-customize
+            config: {}
           # The 'disk_size_mb' field specifies the size in megabytes
           # (MB -- multiples of 1,000,000 bytes) of the disk and file
           # system to be created from the source image.
@@ -546,6 +554,14 @@ cluster:
         boot_disk:
           __replace_dict:
             media_type: null
+            # The 'installer' block specifies the kind of installer to be
+            # used ('virt-customize', 'kickstart', "none") and then
+            # installer specific configuration to be used in setting up
+            # for that installer. There is not currently any configuration
+            # for 'none'.
+            installer:
+              style: null
+              config: {}
     rocky_linux_node:
       pure_base_class: true
       # Use the ubuntu_24_04_node class as a base class and tweak it for
@@ -555,7 +571,13 @@ cluster:
         family: RedHat
       virtual_machine:
         boot_disk:
-          # The distro is Rocky, so use that instead of Ubuntu.
+          # The distro is Rocky, so use that instead of Ubuntu. We need
+          # to use an image that is not only a boot image but contains
+          # the Rocky distribution installation media becase we cannot
+          # pull in a remote base OS installation repo over the network
+          # during Dracut in the install due to issues with network
+          # conflicts with kernel configured static addressing. This
+          # forces us to use the 'cdrom' installation method.
           source_image: https://dl.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9-latest-x86_64-minimal.iso
           source_checksum:
             # The URL locates the file containing the checksum
@@ -569,6 +591,54 @@ cluster:
             # SHA256.
             algorithm: SHA256
           media_type: iso
+          # The 'installer' block specifies the kind of installer to be
+          # used ('virt-customize', 'kickstart', "none") and then
+          # installer specific configuration to be used in setting up
+          # for that installer. Some things can be configured for
+          # kickstart and they are described below.
+          installer:
+            style: kickstart
+            config:
+              # The 'repos' section specifies the base OS packages
+              # installation repo and any extra repos you want to be
+              # able to install packages from.
+              repos:
+                # The base section indicates the type of source and the
+                # location to be used as the source of the base OS
+                # repo. Method options are 'cdrom' and 'url' and the
+                # location specified is where kickstart will look for
+                # the source. By default, we are using the 'cdrom'
+                # method.
+                #
+                # NOTE: while 'url' should be able to be used, in
+                # practice with Rocky 9, it does not work because Dracut
+                # encounters network conflicts with static kernel
+                # addressing (i.e. interface configuration from the
+                # kernel command line) when trying to set up the
+                # networks to retrieve the repository from the URL. At
+                # present the 'url' method is not supported. The
+                # commented out example shows what it might look like
+                # if this issue is resolved.
+                base:
+                  method: cdrom
+                  # method: url
+                  # location: https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/
+
+                # The extra section specifies additional repos by name
+                # and base URL to be made available to the install. The
+                # Rocky 9 'Devel' repo is shown here as an example.
+                extra:
+                  - name: Devel
+                    base_url: https://download.rockylinux.org/pub/rocky/9/devel/x86_64/os/
+              # The packages section lists packages or package groups to
+              # be installed
+              packages:
+                - "@headless-management"
+                - "@legacy-unix"
+                - "@network-server"
+                - "@standard"
+                - "@system-tools"
+                - "kexec-tools"
     rocky_net_boot:
       pure_base_class: true
       parent_class: ubuntu_net_boot

--- a/vtds_cluster_kvm/private/scripts/disk_builder.py
+++ b/vtds_cluster_kvm/private/scripts/disk_builder.py
@@ -115,7 +115,14 @@ class DiskBuilder(metaclass=ABCMeta):
         # exactly one for each node class, and it can be
         # multi-threaded
         with cls.image_lock:
-            info_msg("retrieving disk image '%s' as '%s'" % (url, dest))
+            if not exists(dest):
+                info_msg("retrieving disk image '%s' as '%s'" % (url, dest))
+            else:
+                info_msg(
+                    "'%s' already exists, not retrieving disk image '%s'" % (
+                        dest, url
+                    )
+                )
             while not exists(dest):
                 try:
                     run_cmd('curl', ['-o', dest, '-s', url])

--- a/vtds_cluster_kvm/private/scripts/disk_builder.py
+++ b/vtds_cluster_kvm/private/scripts/disk_builder.py
@@ -96,6 +96,9 @@ class DiskBuilder(metaclass=ABCMeta):
         virtual_machine = node_class.get('virtual_machine', {})
         self.disk_config = virtual_machine.get('boot_disk', {})
         self.boot_disk_path = path_join(self.host_dir, "boot_disk.img")
+        self.installer_config = (
+            self.disk_config.get('installer', {}).get('config', {})
+        )
 
     @classmethod
     def _retrieve_image(cls, url, dest):
@@ -512,10 +515,32 @@ class RedHatISODisk(DiskBuilder):
             if install_root:
                 rmtree(install_root)
         target_dev = self.disk_config.get('target_device', None)
+        # Determine what to use for the distribution base OS repo
+        # location based on the configured installation method.
+        install_method = (
+            self.installer_config
+                .get('repos', {})
+                .get('base', {})
+                .get('method', 'cdrom')
+        )
+        install_location = (
+            self.installer_config
+                .get('repos', {})
+                .get('base', {})
+                .get('location', None)
+        )
+        # If the install method is 'url' then the distribution base OS
+        # repo is located at a URL somewhere. Use that. Otherwise, the
+        # base OS repo is located on the boot medium, so use the ISO
+        # path instead.
+        dist_location = (
+            install_location if install_method == 'url' else self.boot_iso_path
+        )
         return {
             'file_path': self.boot_disk_path,
             'iso_path': self.boot_iso_path,
             'target_device': target_dev,
+            'dist_location': dist_location,
         }
 
 

--- a/vtds_cluster_kvm/private/scripts/node_builder.py
+++ b/vtds_cluster_kvm/private/scripts/node_builder.py
@@ -348,7 +348,7 @@ class RedHatNode(NodeBuilder):
                 boot_disk_info['file_path'], boot_size
             ),
             '--cdrom', boot_disk_info['iso_path'],
-            '--location', boot_disk_info['iso_path'],
+            '--location', boot_disk_info['dist_location'],
             '--extra-args', ' '.join(boot_extra_args),
         ] if boot_disk_info else []
         # The boot string contains all of the boot related

--- a/vtds_cluster_kvm/private/scripts/node_builder.py
+++ b/vtds_cluster_kvm/private/scripts/node_builder.py
@@ -338,12 +338,18 @@ class RedHatNode(NodeBuilder):
             .get('boot_disk', {})
             .get('disk_size_mb', '100000')
         ) / 1000)
+        boot_extra_args = [
+            'rd.shell',
+            'inst.ks=cdrom:/install_files/ks.cfg',
+            'console=ttyS0,115200n8',
+        ]
         boot_disk_opt = [
             '--disk', 'path=%s,size=%s' % (
                 boot_disk_info['file_path'], boot_size
             ),
+            '--cdrom', boot_disk_info['iso_path'],
             '--location', boot_disk_info['iso_path'],
-            '--extra-args', 'inst.ks=cdrom:/install_files/ks.cfg',
+            '--extra-args', ' '.join(boot_extra_args),
         ] if boot_disk_info else []
         # The boot string contains all of the boot related
         # parameters for the VM build, starting with the build


### PR DESCRIPTION
## Summary and Scope

The kickstart file generated for installing Rocky 9 on systems that use it was being created with a couple of deprecated kickstart constructs in it, and the Rocky 9 installation had some hard-coded values that would work quite a bit better as configuration items in it. This PR addresses both of those issues.

This change is backward compatible.

## Issues and Related PRs

* Resolves [VSHA-703](https://jira-pro.it.hpe.com:8443/browse/VSHA-703)

## Testing

This PR was tested by deploying OpenCHAMI on vTDS which uses the Rocky 9 distribution for its management and compute nodes and verifying that all of the parts worked.
